### PR TITLE
Check for config.h before inclusion

### DIFF
--- a/src/modbus.h
+++ b/src/modbus.h
@@ -18,7 +18,9 @@
 #ifndef _MODBUS_H_
 #define _MODBUS_H_
 
+#ifdef HAVE_CONFIG_H
 #include <config.h>
+#endif
 
 /* Add this for macros that defined unix flavor */
 #if (defined(__unix__) || defined(unix)) && !defined(USG)


### PR DESCRIPTION
Not doing so results in modbus.h not being includable into sources outside the libmodbus source tree
