### PR TITLE
Ff/ipv6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,7 @@ AC_CHECK_HEADERS([ \
     netinet/in.h \
     netinet/tcp.h \
     arpa/inet.h \
+    netdb.h \
 ])
 
 # Checks for header files.
@@ -98,7 +99,7 @@ AC_CHECK_DECLS([__CYGWIN__])
 
 # Checks for library functions.
 AC_FUNC_FORK
-AC_CHECK_FUNCS([gettimeofday inet_ntoa memset select socket strerror strlcpy])
+AC_CHECK_FUNCS([gettimeofday inet_ntoa memset select socket strerror strlcpy getaddrinfo])
 
 # Add -Wall -Werror for GCC if not already there
 if test "x$GCC" = "xyes"; then

--- a/src/modbus-tcp-private.h
+++ b/src/modbus-tcp-private.h
@@ -26,9 +26,9 @@
 
 typedef struct _modbus_tcp {
     /* TCP port */
-    int port;
+    char *service;
     /* IP address */
-    char ip[16];
+    char *node;
 } modbus_tcp_t;
 
 #endif /* _MODBUS_TCP_PRIVATE_H_ */

--- a/src/modbus-tcp.h
+++ b/src/modbus-tcp.h
@@ -1,5 +1,6 @@
 /*
  * Copyright © 2001-2010 Stéphane Raimbault <stephane.raimbault@gmail.com>
+ * Copyright © 2010,2011 noris network AG <http://noris.net/>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser Public License as published by
@@ -30,6 +31,7 @@
 #endif
 
 #define MODBUS_TCP_DEFAULT_PORT   502
+#define MODBUS_TCP_DEFAULT_SERVICE "502"
 #define MODBUS_TCP_SLAVE         0xFF
 
 /* Modbus_Application_Protocol_V1_1b.pdf Chapter 4 Section 1 Page 5
@@ -37,8 +39,25 @@
  */
 #define MODBUS_TCP_MAX_ADU_LENGTH  260
 
-modbus_t* modbus_new_tcp(const char *ip_address, int port);
+/**
+ * modbus_new_tcp_pi
+ *
+ * Creates a new Modbus/TCP object with the given node (host) and service
+ * (port) names. "node" can either be an IPv4 address, an IPv6 address, a
+ * hostname, or NULL. If "node" is NULL, modbus_tcp_listen() binds to the "any"
+ * address; modbus_tcp_accept() returns an error. "service" can either be a
+ * port number (passed as a string) or a service name as described in the
+ * services(5) manual page.  If "service" is NULL, the default service "502" is
+ * used. Returns a newly allocated modbus_t* object or NULL on error.
+ */
+modbus_t *modbus_new_tcp_pi (const char *node, const char *service);
 int modbus_tcp_listen(modbus_t *ctx, int nb_connection);
 int modbus_tcp_accept(modbus_t *ctx, int *socket);
+
+#ifdef MODBUS_LEGACY
+modbus_t* modbus_new_tcp(const char *ip_address, int port);
+#else
+# define modbus_new_tcp(n,s) modbus_new_tcp_pi(n,s)
+#endif
 
 #endif /* _MODBUS_TCP_H_ */

--- a/tests/bandwidth-client.c
+++ b/tests/bandwidth-client.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
     }
 
     if (use_backend == TCP) {
-        ctx = modbus_new_tcp("127.0.0.1", 1502);
+        ctx = modbus_new_tcp("127.0.0.1", "1502");
     } else {
         ctx = modbus_new_rtu("/dev/ttyUSB1", 115200, 'N', 8, 1);
         modbus_set_slave(ctx, 1);

--- a/tests/bandwidth-server-many-up.c
+++ b/tests/bandwidth-server-many-up.c
@@ -56,7 +56,7 @@ int main(void)
     /* Maximum file descriptor number */
     int fdmax;
 
-    ctx = modbus_new_tcp("127.0.0.1", 1502);
+    ctx = modbus_new_tcp("127.0.0.1", "1502");
 
     mb_mapping = modbus_mapping_new(MODBUS_MAX_READ_BITS, 0,
                                     MODBUS_MAX_READ_REGISTERS, 0);

--- a/tests/bandwidth-server-one.c
+++ b/tests/bandwidth-server-one.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
     }
 
     if (use_backend == TCP) {
-        ctx = modbus_new_tcp("127.0.0.1", 1502);
+        ctx = modbus_new_tcp("127.0.0.1", "1502");
         socket = modbus_tcp_listen(ctx, 1);
         modbus_tcp_accept(ctx, &socket);
 

--- a/tests/random-test-client.c
+++ b/tests/random-test-client.c
@@ -65,7 +65,7 @@ int main(void)
 */
 
     /* TCP */
-    ctx = modbus_new_tcp("127.0.0.1", 1502);
+    ctx = modbus_new_tcp("127.0.0.1", "1502");
     modbus_set_debug(ctx, TRUE);
 
     if (modbus_connect(ctx) == -1) {

--- a/tests/random-test-server.c
+++ b/tests/random-test-server.c
@@ -28,7 +28,7 @@ int main(void)
     modbus_t *ctx;
     modbus_mapping_t *mb_mapping;
 
-    ctx = modbus_new_tcp("127.0.0.1", 1502);
+    ctx = modbus_new_tcp("127.0.0.1", "1502");
     /* modbus_set_debug(ctx, TRUE); */
 
     mb_mapping = modbus_mapping_new(500, 500, 500, 500);

--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
     }
 
     if (use_backend == TCP) {
-        ctx = modbus_new_tcp("127.0.0.1", 1502);
+        ctx = modbus_new_tcp("127.0.0.1", "1502");
     } else {
         ctx = modbus_new_rtu("/dev/ttyUSB1", 115200, 'N', 8, 1);
     }

--- a/tests/unit-test-server.c
+++ b/tests/unit-test-server.c
@@ -55,7 +55,7 @@ int main(int argc, char*argv[])
     }
 
     if (use_backend == TCP) {
-        ctx = modbus_new_tcp("127.0.0.1", 1502);
+        ctx = modbus_new_tcp("127.0.0.1", "1502");
         query = malloc(MODBUS_TCP_MAX_ADU_LENGTH);
     } else {
         ctx = modbus_new_rtu("/dev/ttyUSB0", 115200, 'N', 8, 1);


### PR DESCRIPTION
Hi Stéphane,

I've updated my _ff/ipv6_ branch to work with the new layout of _libmodbus_. It introduces a new function, `modbus_new_tcp_pi()`, which is able to use service names in addition to port numbers. The old function, `modbus_new_tcp()`, is still available for ABI and (if the right defines are used) API compatibility. It was reimplemented using the new function, so that the old function will also work with hostnames and IPv6 addresses.

Since 2.9.2 is marked as _unstable_ I'm not sure how you want to handle compatibility. If you want to maintain backwards compatibility, I think the way I implemented it is the way to go. If you think that being the unstable branch breaking backwards compatibility is okay, I'd remove the `modbus_new_tcp()` function and macro and rename `modbus_new_tcp_pi()` back to `modbus_new_tcp()`.

In case you were wondering, the "pi" suffix stands for "protocol independent" which is the official UNIX terminology for "IPv6 capable".

Best regards,
—octo
