### PR TITLE
Add register count checks to modbus_reply

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -662,7 +662,8 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
     case _FC_READ_COILS: {
         int nb = (req[offset + 3] << 8) + req[offset + 4];
 
-        if ((address + nb) > mb_mapping->nb_bits) {
+        if ((address + nb) > mb_mapping->nb_bits ||
+			nb > MODBUS_MAX_READ_REGISTERS) {
             if (ctx->debug) {
                 fprintf(stderr, "Illegal data address %0X in read_bits\n",
                         address + nb);
@@ -684,7 +685,8 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
          * function) */
         int nb = (req[offset + 3] << 8) + req[offset + 4];
 
-        if ((address + nb) > mb_mapping->nb_input_bits) {
+        if ((address + nb) > mb_mapping->nb_input_bits ||
+			nb > MODBUS_MAX_READ_REGISTERS) {
             if (ctx->debug) {
                 fprintf(stderr, "Illegal data address %0X in read_input_bits\n",
                         address + nb);
@@ -704,7 +706,8 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
     case _FC_READ_HOLDING_REGISTERS: {
         int nb = (req[offset + 3] << 8) + req[offset + 4];
 
-        if ((address + nb) > mb_mapping->nb_registers) {
+        if ((address + nb) > mb_mapping->nb_registers ||
+			nb > MODBUS_MAX_READ_REGISTERS) {
             if (ctx->debug) {
                 fprintf(stderr, "Illegal data address %0X in read_registers\n",
                         address + nb);
@@ -729,7 +732,8 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
          * function) */
         int nb = (req[offset + 3] << 8) + req[offset + 4];
 
-        if ((address + nb) > mb_mapping->nb_input_registers) {
+        if ((address + nb) > mb_mapping->nb_input_registers ||
+			nb > MODBUS_MAX_READ_REGISTERS) {
             if (ctx->debug) {
                 fprintf(stderr, "Illegal data address %0X in read_input_registers\n",
                         address + nb);
@@ -797,7 +801,8 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
     case _FC_WRITE_MULTIPLE_COILS: {
         int nb = (req[offset + 3] << 8) + req[offset + 4];
 
-        if ((address + nb) > mb_mapping->nb_bits) {
+        if ((address + nb) > mb_mapping->nb_bits ||
+			nb > MODBUS_MAX_WRITE_REGISTERS) {
             if (ctx->debug) {
                 fprintf(stderr, "Illegal data address %0X in write_bits\n",
                         address + nb);
@@ -819,7 +824,8 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
     case _FC_WRITE_MULTIPLE_REGISTERS: {
         int nb = (req[offset + 3] << 8) + req[offset + 4];
 
-        if ((address + nb) > mb_mapping->nb_registers) {
+        if ((address + nb) > mb_mapping->nb_registers ||
+			nb > MODBUS_MAX_WRITE_REGISTERS) {
             if (ctx->debug) {
                 fprintf(stderr, "Illegal data address %0X in write_registers\n",
                         address + nb);
@@ -873,7 +879,9 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
         int nb_write = (req[offset + 7] << 8) + req[offset + 8];
 
         if ((address + nb) > mb_mapping->nb_registers ||
-            (address_write + nb_write) > mb_mapping->nb_registers) {
+            (address_write + nb_write) > mb_mapping->nb_registers ||
+			nb > MODBUS_MAX_RW_WRITE_REGISTERS ||
+			nb_write > MODBUS_MAX_RW_WRITE_REGISTERS) {
             if (ctx->debug) {
                 fprintf(stderr,
                         "Illegal data read address %0X or write address %0X write_and_read_registers\n",


### PR DESCRIPTION
Add checks so modbus_reply returns a
MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS if the count of requested
registers exceeds the spec as noted in modbus.h, line 73ff.
