### PR TITLE
When sending, don't retry forever in ERROR_RECOVERY_LINK mode

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -165,6 +165,7 @@ static int send_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
 {
     int rc;
     int i;
+    int send_attempts = 0;
 
     msg_length = ctx->backend->send_msg_pre(msg, msg_length);
 
@@ -193,10 +194,15 @@ static int send_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
             }
         }
     } while ((ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) &&
-             rc == -1);
+             rc == -1 &&
+             send_attempts++ < MODBUS_MAX_SEND_RETRIES);
 
     if (rc > 0 && rc != msg_length) {
         errno = EMBBADDATA;
+        return -1;
+    }
+    if (send_attempts >= MODBUS_MAX_SEND_RETRIES) {
+        errno = EMBXSFAIL;
         return -1;
     }
 

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -81,6 +81,8 @@ MODBUS_BEGIN_DECLS
 #define MODBUS_MAX_WRITE_REGISTERS         123
 #define MODBUS_MAX_RW_WRITE_REGISTERS      121
 
+#define MODBUS_MAX_SEND_RETRIES            3
+
 /* Random number to avoid errno conflicts */
 #define MODBUS_ENOBASE 112345678
 


### PR DESCRIPTION
This is more inline with receiving, which only closes and reopens the link once.  Sending
should still retry, but just not forever.  Currently hardcoded to 3 times.

This "fixes" issue #39

However, I'm not 100% convinced that this is the best path for everybody? Should the amount be configurable? with the default of 0 being the same as now (forever?)
