### PR TITLE
Proxy - modbus_proxy function

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1567,6 +1567,75 @@ void modbus_mapping_free(modbus_mapping_t *mb_mapping)
     free(mb_mapping);
 }
 
+/**
+ * Take a request received from a master context, pass it to an slave context and then
+ * send the confirmation back to the master.
+ */
+int modbus_proxy(modbus_t* master_ctx, modbus_t* slave_ctx, uint8_t* master_req,
+                 int master_req_length)
+{
+    int offset = master_ctx->backend->header_length;
+    int slave = master_req[offset - 1];
+
+    /* First check request filter */
+    if (master_ctx->backend->filter_request(master_ctx, slave))
+        return 0;
+
+    /* Set slave address */
+    modbus_set_slave(slave_ctx, slave);
+
+    /* Translate request to the slave */
+    int function = master_req[offset++];
+    int addr = ((int) master_req[offset++] << 8);
+    addr |= ((int) master_req[offset++]);
+    int nb = ((int) master_req[offset++] << 8);
+    nb |= ((int) master_req[offset++]);
+    uint8_t buf[MAX_MESSAGE_LENGTH];
+    int buf_length = slave_ctx->backend->build_request_basis(slave_ctx, function, addr, nb, buf);
+    /* Copy the remaining PDU to the request */
+    int l = master_req_length - offset - master_ctx->backend->checksum_length;
+    memcpy(buf + buf_length, master_req + offset, l);
+    buf_length += l;
+
+    /* Send the request to the slave */
+    if (send_msg(slave_ctx, buf, buf_length) < 0) {
+        modbus_reply_exception(master_ctx, master_req, MODBUS_EXCEPTION_GATEWAY_PATH);
+        return -1;
+    }
+
+    /* Receive the response */
+    uint8_t rsp[MAX_MESSAGE_LENGTH];
+    int rsp_length = receive_msg(slave_ctx, rsp, MSG_CONFIRMATION);
+    if (rsp_length < 0) {
+        if (errno == ETIMEDOUT)
+            modbus_reply_exception(master_ctx, master_req, MODBUS_EXCEPTION_GATEWAY_TARGET);
+        else
+            modbus_reply_exception(master_ctx, master_req, MODBUS_EXCEPTION_GATEWAY_PATH);
+        return -1;
+    }
+
+    /* Check response in backend */
+    if (slave_ctx->backend->pre_check_confirmation(slave_ctx, buf, rsp, rsp_length) < 0) {
+        modbus_reply_exception(master_ctx, master_req, MODBUS_EXCEPTION_GATEWAY_TARGET);
+        return -1;
+    }
+
+    /* Translate response to master */
+    offset = slave_ctx->backend->header_length;
+    sft_t sft;
+    sft.slave = rsp[offset - 1];
+    sft.function = rsp[offset];
+    sft.t_id = master_ctx->backend->prepare_response_tid(master_req, &master_req_length);
+    buf_length = master_ctx->backend->build_response_basis(&sft, buf);
+    /* Copy the remaining response data: PDU - function */
+    l = rsp_length - offset - slave_ctx->backend->checksum_length - 1;
+    memcpy(buf + buf_length, rsp + offset + 1, l);
+    buf_length += l;
+
+    /* Send response to master */
+    return send_msg(master_ctx, buf, buf_length);
+}
+
 #ifndef HAVE_STRLCPY
 /*
  * Function strlcpy was originally developed by
@@ -1605,3 +1674,4 @@ size_t strlcpy(char *dest, const char *src, size_t dest_size)
     return (s - src - 1); /* count does not include NUL */
 }
 #endif
+

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -205,6 +205,8 @@ EXPORT int modbus_reply(modbus_t *ctx, const uint8_t *req,
                         int req_length, modbus_mapping_t *mb_mapping);
 EXPORT int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,
                                   unsigned int exception_code);
+EXPORT int modbus_proxy(modbus_t* master_ctx, modbus_t* slave_ctx, uint8_t* master_req,
+                 int master_req_length);
 
 /**
  * UTILS FUNCTIONS


### PR DESCRIPTION
Hello there.

Maybe you won't remember by now but about 4 months ago you rejected a pull request of mine because of formatting issues and also because all the changes were made on master instead of branches (I was a new git user). There were two main issues addressed on those changes:
1. Defective hardware that has echo enabled on the RS485 port.
2. Implementing a function to send requests from one context to another (a proxy).

From those features you seemed interested on the proxy one so here I'm sending you another pull request about that one (you can also grab the echo hardware stuff from my echohw branch, if interested).

I finally found the time this weekend to work on this project again and as you suggested I deleted the old fork an moved the changes to a new branch.

This function was developed to solve the following problem: I have a Single Board Computer (SBC) that acts as the master of a MODBUS/RS485 bus and also has an Ethernet port and I wanted to use it as a bridge between Ethernet and RS485 so that is possible to send MODBUS requests from Ethernet to the devices on the RS485 bus.

The following is the program I used to test the function, this one runs on the SBC to connect the Ethernet and RS485 contexts:

``` C++
/*
 * File:   main.cpp
 */

#include <cstdlib>
#include <iostream>
#include <modbus/modbus.h>

using namespace std;

#ifndef MODBUS_PORT
#define MODBUS_PORT 1502
#endif

inline void debug_msg(string msg) {
#ifdef DEBUG
    cerr << msg << endl;
#endif
}

int main(int argc, char** argv) {
    modbus_t *tcp_ctx, *rtu_ctx;
    string ser_dev;

    if (argc > 1)
        ser_dev = argv[1];
    else
        ser_dev = "/dev/ttts2";

    /* TCP Context -> Server. IP string doesn't matter since 
       is changed to INADDR_ANY by modbus_tcp_listen */
    tcp_ctx = modbus_new_tcp("0.0.0.0", MODBUS_PORT);
    if (!tcp_ctx) {
        debug_msg("Can't create TCP context");
        exit(1);
    }
    /* RS485 Context */
    rtu_ctx = modbus_new_rtu(ser_dev.c_str(), 38400, 'E', 8, 1);
#ifdef DEBUG
    modbus_set_debug(tcp_ctx, 1);
    modbus_set_debug(rtu_ctx, 1);
#endif

    int socket = modbus_tcp_listen(tcp_ctx, 1);
    if (socket < 0) {
        debug_msg("Couldn't listen");
        exit(1);
    }
    for (;;) {

        /* Connect to slave side */
        if (modbus_connect(rtu_ctx) < 0) {
            debug_msg("Can't connect to RTU side");
            exit (1);
        }

        debug_msg("Waiting connection ...");
        int in_socket = modbus_tcp_accept(tcp_ctx, &socket);
        if (in_socket < 0 ) {
            debug_msg("Connect failed");
            exit(1);
        }

        for (;;) {
            debug_msg("Reading request from TCP/IP ...");
            uint8_t tcp_buf[MODBUS_TCP_MAX_ADU_LENGTH];
            int tcp_bs = modbus_receive(tcp_ctx, tcp_buf);
            if (tcp_bs < 0)
                break;

            // Send request to RTU slave
            tcp_bs = modbus_proxy(tcp_ctx, rtu_ctx, tcp_buf, tcp_bs);
        }

        debug_msg("Closing connections");
        modbus_close(tcp_ctx);
        modbus_close(rtu_ctx);
    }

    return 0;
}
```

Now from any other device connected to the Ethernet network I can read the devices on the RS485 by setting the slave address on the TCP context.
