### PR TITLE
_modbus_rtu_send problem when using RTS

### DIFF
--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -89,6 +89,7 @@ typedef struct _modbus_rtu {
 #endif
 #if HAVE_DECL_TIOCM_RTS
     int rts;
+    int onebyte_time;
 #endif
     /* To handle many slaves on the same link */
     int confirmation_to_ignore;

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -296,7 +296,7 @@ ssize_t _modbus_rtu_send(modbus_t *ctx, const uint8_t *req, int req_length)
 
         size = write(ctx->s, req, req_length);
 
-        usleep(_MODBUS_RTU_TIME_BETWEEN_RTS_SWITCH);
+        usleep(ctx_rtu->onebyte_time * req_length + _MODBUS_RTU_TIME_BETWEEN_RTS_SWITCH);
         _modbus_rtu_ioctl_rts(ctx->s, ctx_rtu->rts != MODBUS_RTU_RTS_UP);
 
         return size;
@@ -1059,6 +1059,9 @@ modbus_t* modbus_new_rtu(const char *device,
 #if HAVE_DECL_TIOCM_RTS
     /* The RTS use has been set by default */
     ctx_rtu->rts = MODBUS_RTU_RTS_NONE;
+
+    /* Calculate estimated time in micro second to send one byte */
+    ctx_rtu->onebyte_time = (1000 * 1000) * (1 + data_bit + (parity == 'N' ? 0 : 1) + stop_bit) / baud;
 #endif
 
     ctx_rtu->confirmation_to_ignore = FALSE;


### PR DESCRIPTION
When using RTS, _modbus_rtu_send can't send large data correctly.

Because in typical unix system, write(2) function returns immediately
and sent data actually by device driver,
RTS activation time is insufficient.

I wrote simple patch that calculate RTS activation time.
