### PR TITLE
Sleep a little while reconnecting.

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -189,6 +189,7 @@ static int send_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
 
                 if ((errno == EBADF || errno == ECONNRESET || errno == EPIPE)) {
                     modbus_close(ctx);
+                    usleep(100 * 1000); // Be polite to other tasks
                     modbus_connect(ctx);
                 } else {
                     _sleep_and_flush(ctx);


### PR DESCRIPTION
As this code is called in a forever loop, it should try and be somewhat
polite to any other OS tasks.  At present, with tcp connections to localhost,
and presumably rtu connections to a local serial port, this is a CPU hog if
the remote port is not listening.
