### PR TITLE
Use non-blocking sockets on platforms without SOCK_NONBLOCK (Win32, OS X, iOS)

### DIFF
--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -218,6 +218,19 @@ static int _modbus_tcp_set_ipv4_options(int s)
         return -1;
     }
 
+    /* If the OS does not offer SOCK_NONBLOCK, fall back to setting FIONBIO to make sockets non-blocking */
+    /* Do not care about the return value, this is optional */
+#if !defined(SOCK_NONBLOCK) && defined(FIONBIO)
+#ifdef OS_WIN32
+    /* Setting FIONBIO expects an unsigned long according to MSDN */
+    unsigned long ioctloption = 1;
+    ioctlsocket(s, FIONBIO, &ioctloption);
+#else
+    option = 1;
+    ioctl(s, FIONBIO, &option);
+#endif
+#endif
+    
 #ifndef OS_WIN32
     /**
      * Cygwin defines IPTOS_LOWDELAY but can't handle that flag so it's


### PR DESCRIPTION
Hello Stephane,

Thanks for the clean library.

I needed nonblocking sockets on platforms that do not support `SOCK_NONBLOCK`. I have not played around with the test suite yet and I cannot be specific about what I am doing (sadly). Maybe you or someone else will find this useful :)

What would be needed to get this code merged? Would using `fcntl` with `O_NONBLOCK` be more portable? I have little experience outside of the Apple & Win32 worlds.

The Win32 code is the same as mentioned in a comment on an old pull request:

http://github.com/stephane/libmodbus/pull/19#issuecomment-2359113
