### PR TITLE
Introduce a new debugging function.

### DIFF
--- a/src/dbgprintf.c
+++ b/src/dbgprintf.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2012 oldfaber _at_ gmail.com
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ *  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ *  RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ *  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+ *  USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdarg.h>
+
+#include "modbus-private.h"
+
+#if defined(_WIN32)
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+void dbgprintf(int level_mask, int level, const char *format, ...)
+{
+	va_list vl;
+	int len;
+        /* wvsprintf has a 1024 byte limit and no floating point support */
+	char putbuf[1025];
+	static volatile int locked;
+
+	if ((level_mask & level) == 0) {
+		return;
+	}
+        putbuf[1024] = 0;
+	va_start(vl, format);
+        /* ASCII only */
+	len = wvsprintfA(putbuf, format, vl);
+	va_end(vl);
+	if (locked) {
+		Sleep(0);
+		return;
+	}
+	locked = 1;
+	if (len >= 1024)
+		OutputDebugStringA("!!! wvsprintfA() OVEFLOW\n");
+	else
+		OutputDebugStringA(putbuf);
+	locked = 0;
+}
+
+#else // not #defined(_WIN32)
+
+#include <stdio.h>
+
+void dbgprintf(int level_mask, int level, const char *format, ...)
+{
+	va_list vl;
+
+	if ((level_mask & level) == 0) {
+		return;
+	}
+	va_start(vl, format);
+	vfprintf(stderr, format, vl);
+	va_end(vl);
+}
+
+#endif

--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -132,6 +132,22 @@ void _modbus_init_common(modbus_t *ctx);
 void _error_print(modbus_t *ctx, const char *context);
 int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type);
 
+/* error masks */
+#define PR_ERROR      0x01
+#define PR_MBERR      0x02
+#define PR_MESSAGE    0x04
+#define PR_DATA       0x08
+#define PR_WARN       0x10
+#define PR_ALL        0xFF
+
+/* debug reporting function */
+#if defined(__GNUC__)
+# define FORMAT_TYPE __attribute__ ((format(__printf__,3,4)))
+#else
+# define FORMAT_TYPE
+#endif
+void dbgprintf(int level_mask, int level, const char *fmt, ...) FORMAT_TYPE;
+
 #ifndef HAVE_STRLCPY
 size_t strlcpy(char *dest, const char *src, size_t dest_size);
 #endif

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -36,6 +36,7 @@
 # include <ws2tcpip.h>
 # define SHUT_RDWR 2
 # define close closesocket
+# define ERROR_CODE      WSAGetLastError()
 #else
 # include <sys/socket.h>
 # include <sys/ioctl.h>
@@ -50,6 +51,7 @@
 # include <netinet/tcp.h>
 # include <arpa/inet.h>
 # include <netdb.h>
+# define ERROR_CODE      errno
 #endif
 
 #if !defined(MSG_NOSIGNAL)
@@ -68,8 +70,8 @@ static int _modbus_tcp_init_win32(void)
     WSADATA wsaData;
 
     if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
-        fprintf(stderr, "WSAStartup() returned error code %d\n",
-                (unsigned int)GetLastError());
+        dbgprintf(PR_ERROR, PR_ERROR, "WSAStartup() returned error code %d\n",
+                  (int)GetLastError());
         errno = EIO;
         return -1;
     }
@@ -193,10 +195,8 @@ static int _modbus_tcp_pre_check_confirmation(modbus_t *ctx, const uint8_t *req,
 {
     /* Check TID */
     if (req[0] != rsp[0] || req[1] != rsp[1]) {
-        if (ctx->debug) {
-            fprintf(stderr, "Invalid TID received 0x%X (not 0x%X)\n",
-                    (rsp[0] << 8) + rsp[1], (req[0] << 8) + req[1]);
-        }
+        dbgprintf(ctx->debug, PR_MBERR, "Invalid TID received 0x%X (not 0x%X)\n",
+                  (rsp[0] << 8) + rsp[1], (req[0] << 8) + req[1]);
         errno = EMBBADDATA;
         return -1;
     } else {
@@ -319,9 +319,7 @@ static int _modbus_tcp_connect(modbus_t *ctx)
         return -1;
     }
 
-    if (ctx->debug) {
-        printf("Connecting to %s:%d\n", ctx_tcp->ip, ctx_tcp->port);
-    }
+    dbgprintf(ctx->debug, PR_MESSAGE, "Connecting to %s:%d\n", ctx_tcp->ip, ctx_tcp->port);
 
     addr.sin_family = AF_INET;
     addr.sin_port = htons(ctx_tcp->port);
@@ -364,9 +362,7 @@ static int _modbus_tcp_pi_connect(modbus_t *ctx)
     rc = getaddrinfo(ctx_tcp_pi->node, ctx_tcp_pi->service,
                      &ai_hints, &ai_list);
     if (rc != 0) {
-        if (ctx->debug) {
-            fprintf(stderr, "Error returned by getaddrinfo: %s\n", gai_strerror(rc));
-        }
+        dbgprintf(ctx->debug, PR_ERROR, "Error returned by getaddrinfo: %s\n", gai_strerror(rc));
         errno = ECONNREFUSED;
         return -1;
     }
@@ -390,9 +386,7 @@ static int _modbus_tcp_pi_connect(modbus_t *ctx)
         if (ai_ptr->ai_family == AF_INET)
             _modbus_tcp_set_ipv4_options(s);
 
-        if (ctx->debug) {
-            printf("Connecting to [%s]:%s\n", ctx_tcp_pi->node, ctx_tcp_pi->service);
-        }
+        dbgprintf(ctx->debug, PR_MESSAGE, "Connecting to [%s]:%s\n", ctx_tcp_pi->node, ctx_tcp_pi->service);
 
         rc = _connect(s, ai_ptr->ai_addr, ai_ptr->ai_addrlen, &ctx->response_timeout);
         if (rc == -1) {
@@ -536,9 +530,8 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
     ai_list = NULL;
     rc = getaddrinfo(node, service, &ai_hints, &ai_list);
     if (rc != 0) {
-        if (ctx->debug) {
-            fprintf(stderr, "Error returned by getaddrinfo: %s\n", gai_strerror(rc));
-        }
+        dbgprintf(ctx->debug, PR_ERROR, "Error returned by getaddrinfo: %s\n",
+                  gai_strerror(rc));
         errno = ECONNREFUSED;
         return -1;
     }
@@ -550,9 +543,7 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
         s = socket(ai_ptr->ai_family, ai_ptr->ai_socktype,
                             ai_ptr->ai_protocol);
         if (s < 0) {
-            if (ctx->debug) {
-                perror("socket");
-            }
+            dbgprintf(ctx->debug, PR_ERROR, "socket() error %d", ERROR_CODE);
             continue;
         } else {
             int yes = 1;
@@ -560,9 +551,7 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
                             (void *) &yes, sizeof (yes));
             if (rc != 0) {
                 close(s);
-                if (ctx->debug) {
-                    perror("setsockopt");
-                }
+                dbgprintf(ctx->debug, PR_ERROR, "setsockopt() error %d", ERROR_CODE);
                 continue;
             }
         }
@@ -570,18 +559,14 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
         rc = bind(s, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
         if (rc != 0) {
             close(s);
-            if (ctx->debug) {
-                perror("bind");
-            }
+            dbgprintf(ctx->debug, PR_ERROR, "bind() error %d", ERROR_CODE);
             continue;
         }
 
         rc = listen(s, nb_connection);
         if (rc != 0) {
             close(s);
-            if (ctx->debug) {
-                perror("listen");
-            }
+            dbgprintf(ctx->debug, PR_ERROR, "listen() error %d", ERROR_CODE);
             continue;
         }
 
@@ -619,10 +604,8 @@ int modbus_tcp_accept(modbus_t *ctx, int *socket)
         return -1;
     }
 
-    if (ctx->debug) {
-        printf("The client connection from %s is accepted\n",
-               inet_ntoa(addr.sin_addr));
-    }
+    dbgprintf(ctx->debug, PR_MESSAGE, "The client connection from %s is accepted\n",
+              inet_ntoa(addr.sin_addr));
 
     return ctx->s;
 }
@@ -639,9 +622,7 @@ int modbus_tcp_pi_accept(modbus_t *ctx, int *socket)
         *socket = 0;
     }
 
-    if (ctx->debug) {
-        printf("The client connection is accepted.\n");
-    }
+    dbgprintf(ctx->debug, PR_MESSAGE, "The client connection is accepted.\n");
 
     return ctx->s;
 }
@@ -651,9 +632,7 @@ static int _modbus_tcp_select(modbus_t *ctx, fd_set *rset, struct timeval *tv, i
     int s_rc;
     while ((s_rc = select(ctx->s+1, rset, NULL, NULL, tv)) == -1) {
         if (errno == EINTR) {
-            if (ctx->debug) {
-                fprintf(stderr, "A non blocked signal was caught\n");
-            }
+            dbgprintf(ctx->debug, PR_MESSAGE, "A non blocked signal was caught\n");
             /* Necessary after an error */
             FD_ZERO(rset);
             FD_SET(ctx->s, rset);
@@ -735,7 +714,7 @@ modbus_t* modbus_new_tcp(const char *ip, int port)
     sa.sa_handler = SIG_IGN;
     if (sigaction(SIGPIPE, &sa, NULL) < 0) {
         /* The debug flag can't be set here... */
-        fprintf(stderr, "Coud not install SIGPIPE handler.\n");
+        dbgprintf(ctx->debug, PR_ERROR, "Coud not install SIGPIPE handler.\n");
         return NULL;
     }
 #endif
@@ -754,14 +733,14 @@ modbus_t* modbus_new_tcp(const char *ip, int port)
     dest_size = sizeof(char) * 16;
     ret_size = strlcpy(ctx_tcp->ip, ip, dest_size);
     if (ret_size == 0) {
-        fprintf(stderr, "The IP string is empty\n");
+        dbgprintf(ctx->debug, PR_ERROR, "The IP string is empty\n");
         modbus_free(ctx);
         errno = EINVAL;
         return NULL;
     }
 
     if (ret_size >= dest_size) {
-        fprintf(stderr, "The IP string has been truncated\n");
+        dbgprintf(ctx->debug, PR_ERROR, "The IP string has been truncated\n");
         modbus_free(ctx);
         errno = EINVAL;
         return NULL;
@@ -795,14 +774,14 @@ modbus_t* modbus_new_tcp_pi(const char *node, const char *service)
     dest_size = sizeof(char) * _MODBUS_TCP_PI_NODE_LENGTH;
     ret_size = strlcpy(ctx_tcp_pi->node, node, dest_size);
     if (ret_size == 0) {
-        fprintf(stderr, "The node string is empty\n");
+        dbgprintf(ctx->debug, PR_ERROR, "The node string is empty\n");
         modbus_free(ctx);
         errno = EINVAL;
         return NULL;
     }
 
     if (ret_size >= dest_size) {
-        fprintf(stderr, "The node string has been truncated\n");
+        dbgprintf(ctx->debug, PR_ERROR, "The node string has been truncated\n");
         modbus_free(ctx);
         errno = EINVAL;
         return NULL;
@@ -811,14 +790,14 @@ modbus_t* modbus_new_tcp_pi(const char *node, const char *service)
     dest_size = sizeof(char) * _MODBUS_TCP_PI_SERVICE_LENGTH;
     ret_size = strlcpy(ctx_tcp_pi->service, service, dest_size);
     if (ret_size == 0) {
-        fprintf(stderr, "The service string is empty\n");
+        dbgprintf(ctx->debug, PR_ERROR, "The service string is empty\n");
         modbus_free(ctx);
         errno = EINVAL;
         return NULL;
     }
 
     if (ret_size >= dest_size) {
-        fprintf(stderr, "The service string has been truncated\n");
+        dbgprintf(ctx->debug, PR_ERROR, "The service string has been truncated\n");
         modbus_free(ctx);
         errno = EINVAL;
         return NULL;


### PR DESCRIPTION
PLEASE do not pull yet: this is a request for comments.

Problem:
    If the modbus DLL is linked with a GUI application there is no stderr to write to.
    It may be solved in the application, but it's not often done.

Solution:
    Use the dbgprintf, that behaves differently under windows or other OSes.

Notes
    \* I removed the ctx->debug tests, I thing the speed gain they need is minimal,
      and the new interface allows to dynamically select the verbosity level.
    \* I also had to replace perrors(), because the Windows socket functions DO NOT set
      errno.
- I only touched  modbus-tcp.c, as a proof of concept. 
- The #define of the log level should probably go to a public header.
- I only tested this code under Windows, it may not compile under Linux or other OSes.

Is this acceptable ?

Thank you.
