### PR TITLE
fix alignment problem (build fails with -Werror and -Wcast-align on ARMv...

### DIFF
--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -41,6 +41,7 @@ int main(int argc, char *argv[])
     int nb_points;
     int rc;
     float real;
+    uint32_t ireal;
     struct timeval old_response_timeout;
     struct timeval response_timeout;
     int use_backend;
@@ -325,8 +326,9 @@ int main(int argc, char *argv[])
         tab_rp_registers[0] == (UT_IREAL & 0xFFFF)) {
         printf("OK\n");
     } else {
-        printf("FAILED (%x != %x)\n",
-               *((uint32_t *)tab_rp_registers), UT_IREAL);
+        ireal = (uint32_t) tab_rp_registers[0] & 0xFFFF;
+        ireal |= (uint32_t) tab_rp_registers[1] << 16;
+        printf("FAILED (%x != %x)\n", ireal, UT_IREAL);
         goto close;
     }
 


### PR DESCRIPTION
...5 platform)

On older ARM processors you have to keep in mind CPU can access memory 32bit aligned only. Cross compiling libmodbus with ptxdist and the additional flag -Wcast-align leads to a failing build because libmodbus uses -Werror. This fixes the alignment issue. Tree cross-compiles with these changes, tested however on i386 with Debian Wheezy only.
