### PR TITLE
Enable out-of-source build

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,7 +41,8 @@ AM_CPPFLAGS = \
     -include $(top_builddir)/config.h \
     -DSYSCONFDIR=\""$(sysconfdir)"\" \
     -DLIBEXECDIR=\""$(libexecdir)"\" \
-    -I${top_srcdir}/src
+    -I${top_srcdir}/src \
+    -I${top_builddir}/src
 
 AM_CFLAGS = ${my_CFLAGS}
 


### PR DESCRIPTION
Add top build directory to tests. Otherwise modbus-version.h
won't be found during the build process.

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
