### PR TITLE
VS2010 compatibility fixes

### DIFF
--- a/src/modbus-data.c
+++ b/src/modbus-data.c
@@ -43,19 +43,31 @@
 #if !defined(bswap_32)
 
 #if !defined(bswap_16)
+#if defined(_MSC_VER)
+#define bsawp_16(x) _byteswap_ushort((x))
+#else
+#if defined(_GNUC__)
 #pragma message ("Fallback on C functions for bswap_16")
+#endif //defined(_GNUC__)
 static uint16_t bswap_16(uint16_t x)
 {
     return (x >> 8) | (x << 8);
 }
-#endif
+#endif //defined(_MSC_VER)
+#endif //!defined(bswap_16)
 
+#if defined(_MSC_VER)
+#define bswap_32(x) _byteswap_ulong((unsigned long)(x))
+#else
+#if defined(_GNUC__)
 #pragma message ("Fallback on C functions for bswap_32")
+#endif //defined(_GNUC__)
 static uint32_t bswap_32(uint32_t x)
 {
     return (bswap_16(x & 0xffff) << 16) | (bswap_16(x >> 16));
 }
-#endif
+#endif //defined(_MSC_VER)
+#endif //!defined(bswap_32)
 
 /* Sets many bits from a single byte value (all 8 bits of the byte value are
    set) */

--- a/src/modbus-data.c
+++ b/src/modbus-data.c
@@ -43,15 +43,15 @@
 #if !defined(bswap_32)
 
 #if !defined(bswap_16)
-#   warning "Fallback on C functions for bswap_16"
-static inline uint16_t bswap_16(uint16_t x)
+#pragma message ("Fallback on C functions for bswap_16")
+static uint16_t bswap_16(uint16_t x)
 {
     return (x >> 8) | (x << 8);
 }
 #endif
 
-#   warning "Fallback on C functions for bswap_32"
-static inline uint32_t bswap_32(uint32_t x)
+#pragma message ("Fallback on C functions for bswap_32")
+static uint32_t bswap_32(uint32_t x)
 {
     return (bswap_16(x & 0xffff) << 16) | (bswap_16(x >> 16));
 }

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -121,12 +121,14 @@ static void _sleep_response_timeout(modbus_t *ctx)
 
 int modbus_flush(modbus_t *ctx)
 {
+int rc;
+
     if (ctx == NULL) {
         errno = EINVAL;
         return -1;
     }
 
-    int rc = ctx->backend->flush(ctx);
+    rc = ctx->backend->flush(ctx);
     if (rc != -1 && ctx->debug) {
         /* Not all backends are able to return the number of bytes flushed */
         printf("Bytes flushed (%d)\n", rc);


### PR DESCRIPTION
Issue: 122

This change includes a couple of minor fixes to allow
libmodbus to be built using Visual Studio 2010, specifically:
1. Fix the decleration of rc in modbus_flush() to be in 'C' form
2. Replace #warning with #pragma message
3. Remove inline from bswap_16() and bswap_32()