### PR TITLE
Introduce support for callback functions

### DIFF
--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -86,6 +86,7 @@ struct _modbus {
     int error_recovery;
     struct timeval response_timeout;
     struct timeval byte_timeout;
+    modbus_callback_t callback[MODBUS_CALLBACK_MAX];
     const modbus_backend_t *backend;
     void *backend_data;
 };

--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -44,18 +44,6 @@ typedef enum {
     _MODBUS_BACKEND_TYPE_TCP
 } modbus_backend_type_t;
 
-/*
- *  ---------- Request     Indication ----------
- *  | Client | ---------------------->| Server |
- *  ---------- Confirmation  Response ----------
- */
-typedef enum {
-    /* Request message on the server side */
-    MSG_INDICATION,
-    /* Request message on the client side */
-    MSG_CONFIRMATION
-} msg_type_t;
-
 /* This structure reduces the number of params in functions and so
  * optimizes the speed of execution (~ 37%). */
 typedef struct _sft {
@@ -104,7 +92,7 @@ struct _modbus {
 
 void _modbus_init_common(modbus_t *ctx);
 void _error_print(modbus_t *ctx, const char *context);
-int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type);
+int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, modbus_msg_type_t msg_type);
 
 #ifndef HAVE_STRLCPY
 size_t strlcpy(char *dest, const char *src, size_t dest_size);

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -306,7 +306,7 @@ static int _modbus_rtu_receive(modbus_t *ctx, uint8_t *req)
     modbus_rtu_t *ctx_rtu = ctx->backend_data;
 
     if (ctx_rtu->confirmation_to_ignore) {
-        _modbus_receive_msg(ctx, req, MSG_CONFIRMATION);
+        _modbus_receive_msg(ctx, req, MODBUS_MSG_CONFIRMATION);
         /* Ignore errors and reset the flag */
         ctx_rtu->confirmation_to_ignore = FALSE;
         rc = 0;
@@ -314,7 +314,7 @@ static int _modbus_rtu_receive(modbus_t *ctx, uint8_t *req)
             printf("Confirmation to ignore\n");
         }
     } else {
-        rc = _modbus_receive_msg(ctx, req, MSG_INDICATION);
+        rc = _modbus_receive_msg(ctx, req, MODBUS_MSG_INDICATION);
         if (rc == 0) {
             /* The next expected message is a confirmation to ignore */
             ctx_rtu->confirmation_to_ignore = TRUE;

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -166,7 +166,7 @@ static ssize_t _modbus_tcp_send(modbus_t *ctx, const uint8_t *req, int req_lengt
 }
 
 static int _modbus_tcp_receive(modbus_t *ctx, uint8_t *req) {
-    return _modbus_receive_msg(ctx, req, MSG_INDICATION);
+    return _modbus_receive_msg(ctx, req, MODBUS_MSG_INDICATION);
 }
 
 static ssize_t _modbus_tcp_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length) {

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -219,6 +219,18 @@ MODBUS_API int modbus_reply(modbus_t *ctx, const uint8_t *req,
 MODBUS_API int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,
                                       unsigned int exception_code);
 
+/*
+ *  ---------- Request     Indication ----------
+ *  | Client | ---------------------->| Server |
+ *  ---------- Confirmation  Response ----------
+ */
+typedef enum {
+    /* Request message on the server side */
+    MODBUS_MSG_INDICATION,
+    /* Request message on the client side */
+    MODBUS_MSG_CONFIRMATION
+} modbus_msg_type_t;
+
 /**
  * UTILS FUNCTIONS
  **/

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -231,6 +231,17 @@ typedef enum {
     MODBUS_MSG_CONFIRMATION
 } modbus_msg_type_t;
 
+typedef enum
+{
+    MODBUS_CALLBACK_COMPUTE_META_LENGTH,
+    MODBUS_CALLBACK_COMPUTE_DATA_LENGTH,
+    MODBUS_CALLBACK_MAX
+} modbus_callback_type_t;
+
+typedef int (*modbus_callback_t)(modbus_t *ctx, ...);
+
+MODBUS_API int modbus_register_callback(modbus_t *ctx, modbus_callback_type_t cb_type, modbus_callback_t cb);
+
 /**
  * UTILS FUNCTIONS
  **/


### PR DESCRIPTION
I've a device which implements custom modbus functions. Receiving the response for this functions is only possible when libmodbus knows about the response length. As various device could implement the same function codes its up to the program using the modbus library to calculate/provide the response length correctly. So this two patches are a RFC to deal with such situations.
