### PR TITLE
Introduce offsets in modbus mappings

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -12,6 +12,7 @@ TXT3 = \
         modbus_get_socket.txt \
         modbus_mapping_free.txt \
         modbus_mapping_new.txt \
+        modbus_mapping_offset_new.txt \
         modbus_mask_write_register.txt \
         modbus_new_rtu.txt \
         modbus_new_tcp_pi.txt \

--- a/doc/modbus_mapping_new.txt
+++ b/doc/modbus_mapping_new.txt
@@ -18,6 +18,9 @@ The *modbus_mapping_new()* function shall allocate four arrays to store bits,
 input bits, registers and inputs registers. The pointers are stored in
 modbus_mapping_t structure. All values of the arrays are initialized to zero.
 
+This function is equivalent to a call of the _modbus_mapping_offset_new()_ function
+with all offsets set to zero.
+
 If it isn't necessary to allocate an array for a specific type of data, you can
 pass the zero value in argument, the associated pointer will be NULL.
 
@@ -40,7 +43,7 @@ EXAMPLE
 -------
 [source,c]
 -------------------
-/* The fist value of each array is accessible from the 0 address. */
+/* The first value of each array is accessible from the 0 address. */
 mb_mapping = modbus_mapping_new(BITS_ADDRESS + BITS_NB,
                                 INPUT_BITS_ADDRESS + INPUT_BITS_NB,
                                 REGISTERS_ADDRESS + REGISTERS_NB,

--- a/doc/modbus_mapping_offset_new.txt
+++ b/doc/modbus_mapping_offset_new.txt
@@ -1,0 +1,70 @@
+modbus_mapping_offset_new(3)
+============================
+
+
+NAME
+----
+modbus_mapping_offset_new - allocate four arrays of bits and registers
+
+
+SYNOPSIS
+--------
+*modbus_mapping_t* modbus_mapping_new(int 'nb_bits', int 'offset_bits',
+                                      int 'nb_input_bits', int 'offset_input_bits',
+                                      int 'nb_registers', int 'offset_registers',
+                                      int 'nb_input_registers', int 'offset_input_registers');*
+
+
+DESCRIPTION
+-----------
+The _modbus_mapping_offset_new()_ function shall allocate four arrays to store bits,
+input bits, registers and inputs registers. The pointers are stored in
+modbus_mapping_t structure. All values of the arrays are initialized to zero.
+
+The different offsets make it possible to place the mapping at any address in
+each address space.
+
+If it isn't necessary to allocate an array for a specific type of data, you can
+pass the zero value in argument, the associated pointer will be NULL.
+
+This function is convenient to handle requests in a Modbus server/slave.
+
+
+RETURN VALUE
+------------
+The _modbus_mapping_offset_new()_ function shall return the new allocated structure if
+successful. Otherwise it shall return NULL and set errno.
+
+
+ERRORS
+------
+ENOMEM::
+Not enough memory
+
+
+EXAMPLE
+-------
+[source,c]
+-------------------
+/* The first value of each array is accessible at address 4. */
+mb_mapping = modbus_mapping_offset_new(BITS_ADDRESS + BITS_NB, 4,
+                                INPUT_BITS_ADDRESS + INPUT_BITS_NB, 4,
+                                REGISTERS_ADDRESS + REGISTERS_NB, 4,
+                                INPUT_REGISTERS_ADDRESS + INPUT_REGISTERS_NB, 4);
+if (mb_mapping == NULL) {
+    fprintf(stderr, "Failed to allocate the mapping: %s\n",
+            modbus_strerror(errno));
+    modbus_free(ctx);
+    return -1;
+}
+-------------------
+
+SEE ALSO
+--------
+linkmb:modbus_mapping_free[3]
+
+
+AUTHORS
+-------
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -151,9 +151,13 @@ typedef struct _modbus modbus_t;
 
 typedef struct {
     int nb_bits;
+    int offset_bits;
     int nb_input_bits;
+    int offset_input_bits;
     int nb_input_registers;
+    int offset_input_registers;
     int nb_registers;
+    int offset_registers;
     uint8_t *tab_bits;
     uint8_t *tab_input_bits;
     uint16_t *tab_input_registers;
@@ -204,6 +208,10 @@ MODBUS_API int modbus_write_and_read_registers(modbus_t *ctx, int write_addr, in
                                                uint16_t *dest);
 MODBUS_API int modbus_report_slave_id(modbus_t *ctx, int max_dest, uint8_t *dest);
 
+MODBUS_API modbus_mapping_t* modbus_mapping_offset_new(int nb_bits, int offset_bits,
+                                            int nb_input_bits, int offset_input_bits,
+                                            int nb_registers, int offset_registers,
+                                            int nb_input_registers, int offset_input_registers);
 MODBUS_API modbus_mapping_t* modbus_mapping_new(int nb_bits, int nb_input_bits,
                                             int nb_registers, int nb_input_registers);
 MODBUS_API void modbus_mapping_free(modbus_mapping_t *mb_mapping);


### PR DESCRIPTION
This allows to place the coils/registers at any virtual
start address, not only at address 0. This can be useful e.g.
when the server has to fulfill a specification in which
registers are expected at predefined locations.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>