### PR TITLE
[docs] drop reference to non-existent return data

### DIFF
--- a/doc/modbus_report_slave_id.txt
+++ b/doc/modbus_report_slave_id.txt
@@ -19,7 +19,6 @@ to obtain a description of the controller.
 
 The response stored in 'dest' contains:
 
-* the byte count of the response
 * the slave ID, this unique ID is in reality not unique at all so it's not
   possible to depend on it to know how the information are packed in the
   response.


### PR DESCRIPTION
The report slave id function returns the number of bytes as the _return_
value, and does not include it as the first byte in the dest buffer.

Update documentation to reflect reality.  There's no missing
functionality, just slightly confusing documentation.
