### PR TITLE
[docs] Make clear that memory must be allocated

### DIFF
--- a/doc/modbus_report_slave_id.txt
+++ b/doc/modbus_report_slave_id.txt
@@ -27,6 +27,8 @@ The response stored in 'dest' contains:
 * additional data specific to each controller. For example, libmodbus returns
   the version of the library as a string.
 
+You must take care to allocate enough memory to store the results in 'dest'.
+
 
 RETURN VALUE
 ------------
@@ -38,7 +40,7 @@ EXAMPLE
 -------
 [source,c]
 -------------------
-uint8_t *tab_bytes;
+uint8_t tab_bytes[MODBUS_RTU_MAX_ADU_LENGTH];
 
 ...
 


### PR DESCRIPTION
Memory must be allocated when using the report slave id function, this is
not handled by the function. To be safe when the length of the response is
unknown you can use the constant MODBUS_RTU_MAX_ADU_LENGTH
defined in modbus-rtu.h.

Update documentation just to help people and to point to the useful constant.
