### PR TITLE
Fix bswap macros for Microsoft Visual Studio C 2005 or newer compilers. 2nd try.

### DIFF
--- a/src/modbus-data.c
+++ b/src/modbus-data.c
@@ -39,6 +39,9 @@
 #    define bswap_32 __builtin_bswap32
 #  endif
 #endif
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)
+# define bswap_32 _byteswap_ulong
+#endif
 
 #if !defined(bswap_32)
 


### PR DESCRIPTION
If it is acceptable please merge.
