### PR TITLE
Implemented runtime configurable RTS delay

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -33,6 +33,8 @@ MAN3 = \
         modbus_rtu_set_serial_mode.3 \
         modbus_rtu_get_rts.3 \
         modbus_rtu_set_rts.3 \
+        modbus_rtu_get_rts_delay.3 \
+        modbus_rtu_set_rts_delay.3 \
         modbus_send_raw_request.3 \
         modbus_set_bits_from_bytes.3 \
         modbus_set_bits_from_byte.3 \

--- a/doc/modbus_rtu_get_rts_delay.txt
+++ b/doc/modbus_rtu_get_rts_delay.txt
@@ -1,0 +1,46 @@
+modbus_rtu_get_rts_delay(3)
+===========================
+
+
+NAME
+----
+modbus_rtu_get_rts_delay - get the current RTS delay in RTU
+
+
+SYNOPSIS
+--------
+*int modbus_rtu_get_rts_delay(modbus_t *'ctx');*
+
+
+DESCRIPTION
+-----------
+
+The _modbus_rtu_get_rts_delay()_ function shall get the current Request To Send
+delay period of the libmodbus context 'ctx'.
+
+This function can only be used with a context using a RTU backend.
+
+
+RETURN VALUE
+------------
+The _modbus_rtu_get_rts_delay()_ function shall return the current RTS delay in
+microseconds if successful. Otherwise it shall return -1 and set errno.
+
+
+ERRORS
+------
+*EINVAL*::
+The libmodbus backend is not RTU.
+
+
+SEE ALSO
+--------
+linkmb:modbus_rtu_set_rts_delay[3]
+
+
+AUTHORS
+-------
+Jimmy Bergström <jimmy@ekontroll.com>
+
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/doc/modbus_rtu_set_rts_delay.txt
+++ b/doc/modbus_rtu_set_rts_delay.txt
@@ -1,0 +1,46 @@
+modbus_rtu_set_rts_delay(3)
+===========================
+
+
+NAME
+----
+modbus_rtu_set_rts_delay - set the RTS delay in RTU
+
+
+SYNOPSIS
+--------
+*int modbus_rtu_set_rts_delay(modbus_t *'ctx', int 'us');*
+
+
+DESCRIPTION
+-----------
+
+The _modbus_rtu_set_rts_delay()_ function shall set the Request To Send delay
+period of the libmodbus context 'ctx'.
+
+This function can only be used with a context using a RTU backend.
+
+
+RETURN VALUE
+------------
+The _modbus_rtu_set_rts_delay()_ function shall return 0 if successful.
+Otherwise it shall return -1 and set errno.
+
+
+ERRORS
+------
+*EINVAL*::
+The libmodbus backend is not RTU or a negative delay was specified.
+
+
+SEE ALSO
+--------
+linkmb:modbus_rtu_get_rts_delay[3]
+
+
+AUTHORS
+-------
+Jimmy Bergström <jimmy@ekontroll.com>
+
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -37,10 +37,6 @@
 
 #define _MODBUS_RTU_CHECKSUM_LENGTH    2
 
-/* Time waited beetween the RTS switch before transmit data or after transmit
-   data before to read */
-#define _MODBUS_RTU_TIME_BETWEEN_RTS_SWITCH 10000
-
 #if defined(_WIN32)
 #if !defined(ENOTSUP)
 #define ENOTSUP WSAEOPNOTSUPP
@@ -81,6 +77,7 @@ typedef struct _modbus_rtu {
 #endif
 #if HAVE_DECL_TIOCM_RTS
     int rts;
+    int rts_delay;
     int onebyte_time;
 #endif
     /* To handle many slaves on the same link */

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -44,6 +44,9 @@ MODBUS_API int modbus_rtu_get_serial_mode(modbus_t *ctx);
 MODBUS_API int modbus_rtu_set_rts(modbus_t *ctx, int mode);
 MODBUS_API int modbus_rtu_get_rts(modbus_t *ctx);
 
+MODBUS_API int modbus_rtu_set_rts_delay(modbus_t *ctx, int us);
+MODBUS_API int modbus_rtu_get_rts_delay(modbus_t *ctx);
+
 MODBUS_END_DECLS
 
 #endif /* MODBUS_RTU_H */


### PR DESCRIPTION
The default delay period when toggling the RTS pin used to be 10ms, which was way too much for my application. I have made this patch that sets the default delay time to one byte, which seems like a good default since the standard requires the bus to be quiet for at least 3,5 bytes before a response can be sent.

I have also added set/get functions so that the delay may be changed from the application without requiring the library to be recompiled.