### PR TITLE
Removed function prototype without implementation

### DIFF
--- a/src/modbus.h
+++ b/src/modbus.h
@@ -223,7 +223,6 @@ MODBUS_API void modbus_mapping_free(modbus_mapping_t *mb_mapping);
 MODBUS_API int modbus_send_raw_request(modbus_t *ctx, uint8_t *raw_req, int raw_req_length);
 
 MODBUS_API int modbus_receive(modbus_t *ctx, uint8_t *req);
-MODBUS_API int modbus_receive_from(modbus_t *ctx, int sockfd, uint8_t *req);
 
 MODBUS_API int modbus_receive_confirmation(modbus_t *ctx, uint8_t *rsp);
 


### PR DESCRIPTION
Function modbus_receive_from has no implementation in the library and is not used anywhere.
