### PR TITLE
unit-test-client: fix compilation on compilers not supporting c99 mode

### DIFF
--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -744,8 +744,9 @@ int send_crafted_request(modbus_t *ctx, int function,
 {
     const int EXCEPTION_RC = 2;
     uint8_t rsp[MODBUS_TCP_MAX_ADU_LENGTH];
+    int j;
 
-    for (int j=0; j<2; j++) {
+    for (j=0; j<2; j++) {
         int rc;
 
         req[1] = function;


### PR DESCRIPTION
This fixes the message
"error: 'for' loop initial declarations are only allowed in C99 mode",
spotted during cross-compiling of libmodbus.

The compiler (gcc) actually does support -std=c99 but it gets not
enabled by default. So a solution would be to enforce c99 mode
via CFLAGS, but this will knock out all compilers which do not
support this mode.
Moving the declaration out of the loop initialisation, seems to be
the simpler solution.

Signed-off-by: Michael Heimpold mhei@heimpold.de
