### PR TITLE
Do not reply on broadcast requests (fixes #153)

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1053,7 +1053,8 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
         break;
     }
 
-    return send_msg(ctx, rsp, rsp_length);
+    /* Suppress any response when the request was a broadcast */
+    return slave ? send_msg(ctx, rsp, rsp_length) : 0;
 }
 
 int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,

--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -428,8 +428,8 @@ int main(int argc, char *argv[])
 
     rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS,
                                UT_REGISTERS_NB, tab_rp_registers);
-    printf("2/3 Reply after a broadcast query: ");
-    ASSERT_TRUE(rc == UT_REGISTERS_NB, "");
+    printf("2/3 No reply after a broadcast query: ");
+    ASSERT_TRUE(rc == -1 && errno == ETIMEDOUT, "");
 
     /* Restore slave */
     if (use_backend == RTU) {


### PR DESCRIPTION
According to the Modbus specification
(http://www.modbus.org/docs/Modbus_over_serial_line_V1_02.pdf, section 2.1)
a Modbus RTU master can send a broadcast to all of it's slaves. This
broadcasts can only be write requests as otherwise collisions could
occur, eg. on a RS-485 bus.

When receiving such a broadcast, the slave should process the request as
usual, but must not reply anything, neither a normal response nor an
exception reply in case of an error.

Adjust the unit test for this case, too.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>