### PR TITLE
modbus_send_raw_request: limit request length (fixes #207)

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -217,8 +217,10 @@ int modbus_send_raw_request(modbus_t *ctx, uint8_t *raw_req, int raw_req_length)
         return -1;
     }
 
-    if (raw_req_length < 2) {
-        /* The raw request must contain function and slave at least */
+    if (raw_req_length < 2 || raw_req_length > (MODBUS_MAX_PDU_LENGTH + 1)) {
+        /* The raw request must contain function and slave at least and
+           must not be longer than the maximum pdu length plus the slave
+           address. */
         errno = EINVAL;
         return -1;
     }


### PR DESCRIPTION
Do not allow raw request length longer than the PDU size plus
the additional requested slave address byte.
Without this check modbus_send_raw_request could be used to
trigger a buffer overflow on the stack since the parameter
is passed unchecked to memcpy.

Thanks to Hanno Neuer for spotting this security flaw.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>