### PR TITLE
RTU: don't abort if line control settings can't be set.

### DIFF
--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -897,9 +897,8 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     tios.c_cc[VTIME] = 0;
 
     if (tcsetattr(ctx->s, TCSANOW, &tios) < 0) {
-        close(ctx->s);
-        ctx->s = -1;
-        return -1;
+        fprintf(stderr, "Failed to set termios! Line control must be set manually!"
+		" err: %s\n", strerror(errno));
     }
 #endif
 


### PR DESCRIPTION
While it's definitely a cause for concern if the line can't be set as
expected, there are many useful situations where the line cannot be
configured, but doesn't need to be.  Aborting for those cases prevents
the use of virtual serial ports for instance.

Signed-off-by: Karl Palsson karlp@remake.is

This fixes: https://github.com/stephane/libmodbus/issues/234 allowing not just the serial to network forwarding from that issue, but also allows serial line snooping via:

```
socat -d -d -lu -x  PTY,link=/tmp/serial,raw /dev/ttyUSB1,raw
```
