### PR TITLE
Introduce SPDX license identifiers

### DIFF
--- a/src/modbus-data.c
+++ b/src/modbus-data.c
@@ -1,19 +1,7 @@
 /*
  * Copyright © 2010-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-License-Identifier: LGPL-2.1+
  */
 
 #include <stdlib.h>

--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -1,19 +1,7 @@
 /*
  * Copyright © 2010-2012 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-License-Identifier: LGPL-2.1+
  */
 
 #ifndef MODBUS_PRIVATE_H

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -1,19 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-License-Identifier: LGPL-2.1+
  */
 
 #ifndef MODBUS_RTU_PRIVATE_H

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -1,19 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-License-Identifier: LGPL-2.1+
  */
 
 #include <stdio.h>

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -1,19 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-License-Identifier: LGPL-2.1+
  */
 
 #ifndef MODBUS_RTU_H

--- a/src/modbus-tcp-private.h
+++ b/src/modbus-tcp-private.h
@@ -1,19 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-License-Identifier: LGPL-2.1+
  */
 
 #ifndef MODBUS_TCP_PRIVATE_H

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -1,19 +1,7 @@
 /*
  * Copyright © 2001-2013 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-License-Identifier: LGPL-2.1+
  */
 
 #include <stdio.h>

--- a/src/modbus-tcp.h
+++ b/src/modbus-tcp.h
@@ -1,19 +1,7 @@
 /*
  * Copyright © 2001-2010 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-License-Identifier: LGPL-2.1+
  */
 
 #ifndef MODBUS_TCP_H

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1,20 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- *
+ * SPDX-License-Identifier: LGPL-2.1+
  *
  * This library implements the Modbus protocol.
  * http://libmodbus.org/

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -1,19 +1,7 @@
 /*
  * Copyright © 2001-2013 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-License-Identifier: LGPL-2.1+
  */
 
 #ifndef MODBUS_H

--- a/tests/bandwidth-client.c
+++ b/tests/bandwidth-client.c
@@ -1,8 +1,7 @@
 /*
  * Copyright © 2008-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the BSD License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stdio.h>

--- a/tests/bandwidth-server-many-up.c
+++ b/tests/bandwidth-server-many-up.c
@@ -1,8 +1,7 @@
 /*
  * Copyright © 2008-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the BSD License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stdio.h>

--- a/tests/bandwidth-server-one.c
+++ b/tests/bandwidth-server-one.c
@@ -1,8 +1,7 @@
 /*
  * Copyright © 2008-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the BSD License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stdio.h>

--- a/tests/random-test-client.c
+++ b/tests/random-test-client.c
@@ -1,8 +1,7 @@
 /*
  * Copyright © 2008-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the BSD License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stdio.h>

--- a/tests/random-test-server.c
+++ b/tests/random-test-server.c
@@ -1,8 +1,7 @@
 /*
  * Copyright © 2008-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the BSD License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stdio.h>

--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -1,8 +1,7 @@
 /*
  * Copyright © 2008-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the BSD License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stdio.h>

--- a/tests/unit-test-client.log
+++ b/tests/unit-test-client.log
@@ -1,0 +1,259 @@
+Connecting to 127.0.0.1:1502
+** UNIT TESTING **
+1/1 No response timeout modification on connect: OK
+
+TEST WRITE/READ:
+[00][01][00][00][00][06][FF][05][01][30][FF][00]
+Waiting for a confirmation...
+<00><01><00><00><00><06><FF><05><01><30><FF><00>
+1/2 modbus_write_bit: OK
+[00][02][00][00][00][06][FF][01][01][30][00][01]
+Waiting for a confirmation...
+<00><02><00><00><00><04><FF><01><01><01>
+2/2 modbus_read_bits: OK
+OK
+[00][03][00][00][00][0C][FF][0F][01][30][00][25][05][CD][6B][B2][0E][1B]
+Waiting for a confirmation...
+<00><03><00><00><00><06><FF><0F><01><30><00><25>
+1/2 modbus_write_bits: OK
+[00][04][00][00][00][06][FF][01][01][30][00][25]
+Waiting for a confirmation...
+<00><04><00><00><00><08><FF><01><05><CD><6B><B2><0E><1B>
+2/2 modbus_read_bits: OK
+OK
+OK
+OK
+OK
+OK
+OK
+[00][05][00][00][00][06][FF][02][01][C4][00][16]
+Waiting for a confirmation...
+<00><05><00><00><00><06><FF><02><03><AC><DB><35>
+1/1 modbus_read_input_bits: OK
+OK
+OK
+OK
+OK
+[00][06][00][00][00][06][FF][06][01][6B][12][34]
+Waiting for a confirmation...
+<00><06><00><00><00><06><FF><06><01><6B><12><34>
+1/2 modbus_write_register: OK
+[00][07][00][00][00][06][FF][03][01][6B][00][01]
+Waiting for a confirmation...
+<00><07><00><00><00><05><FF><03><02><12><34>
+2/2 modbus_read_registers: OK
+OK
+[00][08][00][00][00][0D][FF][10][01][6B][00][03][06][02][2B][00][01][00][64]
+Waiting for a confirmation...
+<00><08><00><00><00><06><FF><10><01><6B><00><03>
+1/5 modbus_write_registers: OK
+[00][09][00][00][00][06][FF][03][01][6B][00][03]
+Waiting for a confirmation...
+<00><09><00><00><00><09><FF><03><06><02><2B><00><01><00><64>
+2/5 modbus_read_registers: OK
+OK
+OK
+OK
+[00][0A][00][00][00][06][FF][03][01][6B][00][00]
+Waiting for a confirmation...
+<00><0A><00><00><00><03><FF><83><03>
+3/5 modbus_read_registers (0): OK
+[00][0B][00][00][00][0F][FF][17][01][6B][00][03][01][6C][00][02][04][00][00][00][00]
+Waiting for a confirmation...
+<00><0B><00><00><00><09><FF><17><06><02><2B><00><00><00><00>
+4/5 modbus_write_and_read_registers: OK
+OK
+OK
+OK
+[00][0C][00][00][00][06][FF][04][01][08][00][01]
+Waiting for a confirmation...
+<00><0C><00><00><00><05><FF><04><02><00><0A>
+1/1 modbus_read_input_registers: OK
+OK
+
+TEST FLOATS
+1/4 Set float: OK
+2/4 Get float: OK
+3/4 Set float in DBCA order: OK
+4/4 Get float in DCBA order: OK
+
+At this point, error messages doesn't mean the test has failed
+
+TEST ILLEGAL DATA ADDRESS:
+[00][0D][00][00][00][06][FF][01][01][30][00][26]
+Waiting for a confirmation...
+<00><0D><00><00><00><03><FF><81><02>
+* modbus_read_bits: OK
+[00][0E][00][00][00][06][FF][02][01][C4][00][17]
+Waiting for a confirmation...
+<00><0E><00><00><00><03><FF><82><02>
+* modbus_read_input_bits: OK
+[00][0F][00][00][00][06][FF][03][01][6B][00][04]
+Waiting for a confirmation...
+<00><0F><00><00><00><03><FF><83><02>
+* modbus_read_registers: OK
+[00][10][00][00][00][06][FF][04][01][08][00][02]
+Waiting for a confirmation...
+<00><10><00><00><00><03><FF><84><02>
+* modbus_read_input_registers: OK
+[00][11][00][00][00][06][FF][05][01][55][FF][00]
+Waiting for a confirmation...
+<00><11><00><00><00><03><FF><85><02>
+* modbus_write_bit: OK
+[00][12][00][00][00][0C][FF][0F][01][55][00][25][05][AC][DB][B5][0E][1B]
+Waiting for a confirmation...
+<00><12><00><00><00><03><FF><8F><02>
+* modbus_write_coils: OK
+[00][13][00][00][00][06][FF][03][01][6E][00][03]
+Waiting for a confirmation...
+<00><13><00><00><00><03><FF><83><02>
+* modbus_write_registers: OK
+
+TEST TOO MANY DATA ERROR:
+* modbus_read_bits: OK
+* modbus_read_input_bits: OK
+* modbus_read_registers: OK
+* modbus_read_input_registers: OK
+* modbus_write_bits: OK
+* modbus_write_registers: OK
+
+TEST SLAVE REPLY:
+[00][14][00][00][00][06][12][03][01][6B][00][03]
+Waiting for a confirmation...
+<00><14><00><00><00><09><12><03><06><02><2B><00><00><00><00>
+1/3 Response from slave 18: OK
+OK
+[00][15][00][00][00][06][00][03][01][6B][00][03]
+Waiting for a confirmation...
+<00><15><00><00><00><09><00><03><06><02><2B><00><00><00><00>
+2/3 Reply after a broadcast query: OK
+3/3 Response with an invalid TID or slave: [00][16][00][00][00][06][FF][03][00][6D][00][01]
+Waiting for a confirmation...
+<00><00><00><00><00><05><FF><03><02><00><00>
+Bytes flushed (0)
+OK
+1/2 Report slave ID truncated: 
+[00][17][00][00][00][02][FF][11]
+Waiting for a confirmation...
+<00><17><00><00><00><0D><FF><11><0A><B4><FF><4C><4D><42><33><2E><31><2E><31>
+OK
+2/2 Report slave ID: 
+[00][18][00][00][00][02][FF][11]
+Waiting for a confirmation...
+<00><18><00><00><00><0D><FF><11><0A><B4><FF><4C><4D><42><33><2E><31><2E><31>
+OK
+OK
+OK
+Additional data: LMB3.1.1
+1/6 Invalid response timeout (zero): OK
+2/6 Invalid response timeout (too large us): OK
+3/6 Invalid byte timeout (too large us): OK
+[00][19][00][00][00][06][FF][03][01][6B][00][03]
+Waiting for a confirmation...
+<00><19><00><00><00><09><FF><03><06><02><2B><00><00><00><00>
+4/6 1us response timeout: FAILED (can fail on some platforms)
+Bytes flushed (0)
+[00][1A][00][00][00][06][FF][03][00][6E][00][01]
+Waiting for a confirmation...
+Bytes flushed (0)
+5/6 Too short response timeout (0.2s < 0.5s): OK
+Bytes flushed (11)
+[00][1B][00][00][00][06][FF][03][00][6E][00][01]
+Waiting for a confirmation...
+<00><1B><00><00><00><05><FF><03><02><00><00>
+6/6 Adequate response timeout (0.6s > 0.5s): OK
+[00][1C][00][00][00][06][FF][03][00][6E][00][01]
+Waiting for a confirmation...
+<00><1C><00><00><00><05><FF><03><02><00><00>
+7/7 Disable byte timeout: OK
+[00][1D][00][00][00][06][FF][03][00][6F][00][01]
+Waiting for a confirmation...
+<00>Bytes flushed (10)
+1/2 Too small byte timeout (3ms < 5ms): OK
+Bytes flushed (0)
+[00][1E][00][00][00][06][FF][03][00][6F][00][01]
+Waiting for a confirmation...
+<00><1E><00><00><00><05><FF><03><02><00><00>
+2/2 Adapted byte timeout (7ms > 5ms): OK
+
+TEST BAD RESPONSE ERROR:
+[00][1F][00][00][00][06][FF][03][01][6B][00][02]
+Waiting for a confirmation...
+<00><1F><00><00><00><05><FF><03><02><02><2B>
+Bytes flushed (0)
+* modbus_read_registers: OK
+
+TEST MANUAL EXCEPTION:
+[00][20][00][00][00][06][FF][03][00][6C][00][03]
+Waiting for a confirmation...
+<00><20><00><00><00><03><FF><83><06>
+* modbus_read_registers at special address: OK
+
+TEST RAW REQUESTS:
+[00][00][00][00][00][06][FF][03][00][01][00][05]
+* modbus_send_raw_request: OK
+* modbus_receive_confirmation: Waiting for a confirmation...
+<00><00><00><00><00><0D><FF><03><0A><00><00><00><00><00><00><00><00><00><00>
+OK
+[00][00][00][00][00][06][FF][01][00][01][00][00]
+* try function 0x1: read 0 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><81><03>
+OK
+[00][00][00][00][00][06][FF][01][00][01][07][D1]
+* try function 0x1: read 2001 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><81><03>
+OK
+[00][00][00][00][00][06][FF][02][00][01][00][00]
+* try function 0x2: read 0 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><82><03>
+OK
+[00][00][00][00][00][06][FF][02][00][01][07][D1]
+* try function 0x2: read 2001 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><82><03>
+OK
+[00][00][00][00][00][06][FF][03][00][01][00][00]
+* try function 0x3: read 0 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><83><03>
+OK
+[00][00][00][00][00][06][FF][03][00][01][00][7E]
+* try function 0x3: read 126 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><83><03>
+OK
+[00][00][00][00][00][06][FF][04][00][01][00][00]
+* try function 0x4: read 0 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><84><03>
+OK
+[00][00][00][00][00][06][FF][04][00][01][00][7E]
+* try function 0x4: read 126 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><84><03>
+OK
+[00][00][00][00][00][0D][FF][17][00][00][00][00][00][00][00][01][02][12][34]
+* try function 0x17: read 0 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><97><03>
+OK
+[00][00][00][00][00][0D][FF][17][00][00][00][7E][00][00][00][01][02][12][34]
+* try function 0x17: read 126 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><97><03>
+OK
+[00][00][00][00][00][0D][FF][10][01][6B][00][00][00][02][2B][00][01][00][64]
+* try function 0x10: write 0 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><90><03>
+OK
+[00][00][00][00][00][0D][FF][10][01][6B][00][7C][06][02][2B][00][01][00][64]
+* try function 0x10: write 124 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><90><03>
+OK
+[00][00][00][00][00][0D][FF][0F][01][6B][00][00][00][02][2B][00][01][00][64]
+* try function 0xF: write 0 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><8F><03>
+OK
+[00][00][00][00][00][0D][FF][0F][01][6B][07][B1][06][02][2B][00][01][00][64]
+* try function 0xF: write 1969 values: Waiting for a confirmation...
+<00><00><00><00><00><03><FF><8F><03>
+OK
+
+TEST INVALID INITIALIZATION:
+OK
+OK
+
+ALL TESTS PASS WITH SUCCESS.

--- a/tests/unit-test-server.c
+++ b/tests/unit-test-server.c
@@ -1,8 +1,7 @@
 /*
  * Copyright © 2008-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the BSD License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stdio.h>

--- a/tests/unit-test-server.log
+++ b/tests/unit-test-server.log
@@ -1,0 +1,187 @@
+Illegal nb of values 0 in read_holding_registers (max 125)
+Illegal data address 156 in read_bits
+Illegal data address 1DB in read_input_bits
+Illegal data address 16F in read_registers
+Illegal data address 10A in read_input_registers
+Illegal data address 155 in write_bit
+Illegal data address 17A in write_bits
+Illegal data address 171 in read_registers
+The client connection from 127.0.0.1 is accepted
+Waiting for a indication...
+<00><01><00><00><00><06><FF><05><01><30><FF><00>
+[00][01][00][00][00][06][FF][05][01][30][FF][00]
+Waiting for a indication...
+<00><02><00><00><00><06><FF><01><01><30><00><01>
+[00][02][00][00][00][04][FF][01][01][01]
+Waiting for a indication...
+<00><03><00><00><00><0C><FF><0F><01><30><00><25><05><CD><6B><B2><0E><1B>
+[00][03][00][00][00][06][FF][0F][01][30][00][25]
+Waiting for a indication...
+<00><04><00><00><00><06><FF><01><01><30><00><25>
+[00][04][00][00][00][08][FF][01][05][CD][6B][B2][0E][1B]
+Waiting for a indication...
+<00><05><00><00><00><06><FF><02><01><C4><00><16>
+[00][05][00][00][00][06][FF][02][03][AC][DB][35]
+Waiting for a indication...
+<00><06><00><00><00><06><FF><06><01><6B><12><34>
+[00][06][00][00][00][06][FF][06][01][6B][12][34]
+Waiting for a indication...
+<00><07><00><00><00><06><FF><03><01><6B><00><01>
+[00][07][00][00][00][05][FF][03][02][12][34]
+Waiting for a indication...
+<00><08><00><00><00><0D><FF><10><01><6B><00><03><06><02><2B><00><01><00><64>
+[00][08][00][00][00][06][FF][10][01][6B][00][03]
+Waiting for a indication...
+<00><09><00><00><00><06><FF><03><01><6B><00><03>
+[00][09][00][00][00][09][FF][03][06][02][2B][00][01][00][64]
+Waiting for a indication...
+<00><0A><00><00><00><06><FF><03><01><6B><00><00>
+Bytes flushed (0)
+[00][0A][00][00][00][03][FF][83][03]
+Waiting for a indication...
+<00><0B><00><00><00><0F><FF><17><01><6B><00><03><01><6C><00><02><04><00><00><00><00>
+[00][0B][00][00][00][09][FF][17][06][02][2B][00][00][00][00]
+Waiting for a indication...
+<00><0C><00><00><00><06><FF><04><01><08><00><01>
+[00][0C][00][00][00][05][FF][04][02][00][0A]
+Waiting for a indication...
+<00><0D><00><00><00><06><FF><01><01><30><00><26>
+[00][0D][00][00][00][03][FF][81][02]
+Waiting for a indication...
+<00><0E><00><00><00><06><FF><02><01><C4><00><17>
+[00][0E][00][00][00][03][FF][82][02]
+Waiting for a indication...
+<00><0F><00><00><00><06><FF><03><01><6B><00><04>
+[00][0F][00][00][00][03][FF][83][02]
+Waiting for a indication...
+<00><10><00><00><00><06><FF><04><01><08><00><02>
+[00][10][00][00][00][03][FF][84][02]
+Waiting for a indication...
+<00><11><00><00><00><06><FF><05><01><55><FF><00>
+Bytes flushed (0)
+[00][11][00][00][00][03][FF][85][02]
+Waiting for a indication...
+<00><12><00><00><00><0C><FF><0F><01><55><00><25><05><AC><DB><B5><0E><1B>
+[00][12][00][00][00][03][FF][8F][02]
+Waiting for a indication...
+<00><13><00><00><00><06><FF><03><01><6E><00><03>
+[00][13][00][00][00][03][FF][83][02]
+Waiting for a indication...
+<00><14><00><00><00><06><12><03><01><6B><00><03>
+[00][14][00][00][00][09][12][03][06][02][2B][00][00][00][00]
+Waiting for a indication...
+<00><15><00><00><00><06><00><03><01><6B><00><03>
+[00][15][00][00][00][09][00][03][06][02][2B][00][00][00][00]
+Waiting for a indication...
+<00><16><00><00><00><06><FF><03><00><6D><00><01>
+Reply with an invalid TID or slave
+[00][00][00][00][00][05][FF][03][02][00][00]
+Waiting for a indication...
+<00><17><00><00><00><02><FF><11>
+[00][17][00][00][00][0D][FF][11][0A][B4][FF][4C][4D][42][33][2E][31][2E][31]
+Waiting for a indication...
+<00><18><00><00><00><02><FF><11>
+[00][18][00][00][00][0D][FF][11][0A][B4][FF][4C][4D][42][33][2E][31][2E][31]
+Waiting for a indication...
+<00><19><00><00><00><06><FF><03><01><6B><00><03>
+[00][19][00][00][00][09][FF][03][06][02][2B][00][00][00][00]
+Waiting for a indication...
+<00><1A><00><00><00><06><FF><03><00><6E><00><01>
+Sleep 0.5 s before replying
+[00][1A][00][00][00][05][FF][03][02][00][00]
+Waiting for a indication...
+<00><1B><00><00><00><06><FF><03><00><6E><00><01>
+Sleep 0.5 s before replying
+[00][1B][00][00][00][05][FF][03][02][00][00]
+Waiting for a indication...
+<00><1C><00><00><00><06><FF><03><00><6E><00><01>
+Sleep 0.5 s before replying
+[00][1C][00][00][00][05][FF][03][02][00][00]
+Waiting for a indication...
+<00><1D><00><00><00><06><FF><03><00><6F><00><01>
+(00)(1D)(00)(00)(00)(05)(FF)(03)(02)(00)(00)Waiting for a indication...
+<00><1E><00><00><00><06><FF><03><00><6F><00><01>
+(00)(1E)(00)(00)(00)(05)(FF)(03)(02)(00)(00)Waiting for a indication...
+<00><1F><00><00><0Illegal nb of values 0 in read_bits (max 2000)
+Illegal nb of values 2001 in read_bits (max 2000)
+Illegal nb of values 0 in read_input_bits (max 2000)
+Illegal nb of values 2001 in read_input_bits (max 2000)
+Illegal nb of values 0 in read_holding_registers (max 125)
+Illegal nb of values 126 in read_holding_registers (max 125)
+Illegal number of values 0 in read_input_registers (max 125)
+Illegal number of values 126 in read_input_registers (max 125)
+Illegal nb of values (W1, R0) in write_and_read_registers (max W121, R125)
+Illegal nb of values (W1, R126) in write_and_read_registers (max W121, R125)
+Illegal number of values 0 in write_registers (max 123)
+Illegal number of values 124 in write_registers (max 123)
+Illegal number of values 0 in write_bits (max 1968)
+Illegal number of values 1969 in write_bits (max 1968)
+ERROR Connection reset by peer: read
+0><06><FF><03><01><6B><00><02>
+Set an incorrect number of values
+[00][1F][00][00][00][05][FF][03][02][02][2B]
+Waiting for a indication...
+<00><20><00><00><00><06><FF><03><00><6C><00><03>
+Reply to this special register address by an exception
+[00][20][00][00][00][03][FF][83][06]
+Waiting for a indication...
+<00><00><00><00><00><06><FF><03><00><01><00><05>
+[00][00][00][00][00][0D][FF][03][0A][00][00][00][00][00][00][00][00][00][00]
+Waiting for a indication...
+<00><00><00><00><00><06><FF><01><00><01><00><00>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][81][03]
+Waiting for a indication...
+<00><00><00><00><00><06><FF><01><00><01><07><D1>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][81][03]
+Waiting for a indication...
+<00><00><00><00><00><06><FF><02><00><01><00><00>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][82][03]
+Waiting for a indication...
+<00><00><00><00><00><06><FF><02><00><01><07><D1>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][82][03]
+Waiting for a indication...
+<00><00><00><00><00><06><FF><03><00><01><00><00>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][83][03]
+Waiting for a indication...
+<00><00><00><00><00><06><FF><03><00><01><00><7E>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][83][03]
+Waiting for a indication...
+<00><00><00><00><00><06><FF><04><00><01><00><00>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][84][03]
+Waiting for a indication...
+<00><00><00><00><00><06><FF><04><00><01><00><7E>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][84][03]
+Waiting for a indication...
+<00><00><00><00><00><0D><FF><17><00><00><00><00><00><00><00><01><02><12><34>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][97][03]
+Waiting for a indication...
+<00><00><00><00><00><0D><FF><17><00><00><00><7E><00><00><00><01><02><12><34>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][97][03]
+Waiting for a indication...
+<00><00><00><00><00><0D><FF><10><01><6B><00><00><00>
+Bytes flushed (6)
+[00][00][00][00][00][03][FF][90][03]
+Waiting for a indication...
+<00><00><00><00><00><0D><FF><10><01><6B><00><7C><06><02><2B><00><01><00><64>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][90][03]
+Waiting for a indication...
+<00><00><00><00><00><0D><FF><0F><01><6B><00><00><00>
+Bytes flushed (6)
+[00][00][00][00][00][03][FF][8F][03]
+Waiting for a indication...
+<00><00><00><00><00><0D><FF><0F><01><6B><07><B1><06><02><2B><00><01><00><64>
+Bytes flushed (0)
+[00][00][00][00][00][03][FF][8F][03]
+Waiting for a indication...
+Quit the loop: Connection reset by peer

--- a/tests/unit-test.h.in
+++ b/tests/unit-test.h.in
@@ -1,8 +1,7 @@
 /*
  * Copyright © 2008-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the BSD License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _UNIT_TEST_H_

--- a/tests/version.c
+++ b/tests/version.c
@@ -1,8 +1,7 @@
 /*
  * Copyright © 2008-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the BSD License.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stdio.h>


### PR DESCRIPTION
This replaces the lengthy license text headers with a short
and standardized license tag. See http://spdx.org for details.

This is useful e.g. for license compliance tools which scan
through files and generate a report of the licenses used
in a project.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>