### PR TITLE
fix rts signal switch time

### DIFF
--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -27,7 +27,7 @@
 
 /* Time waited beetween the RTS switch before transmit data or after transmit
    data before to read */
-#define _MODBUS_RTU_TIME_BETWEEN_RTS_SWITCH 10000
+#define _MODBUS_RTU_TIME_BETWEEN_RTS_SWITCH 1000
 
 #if defined(_WIN32)
 #if !defined(ENOTSUP)


### PR DESCRIPTION
According to the document, if you enable the rts mode in modbus rtu, it has been written as "1ms delay time is generated".

However, I and try to observe the waveform, 10ms delay time was being generated.

So, when I look at the source code, I found a mistake.

I propose the improvement.