### PR TITLE
Adds a method that enable raw replies

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -241,6 +241,43 @@ int modbus_send_raw_request(modbus_t *ctx, uint8_t *raw_req, int raw_req_length)
     return send_msg(ctx, req, req_length);
 }
 
+int modbus_send_raw_reply(modbus_t *ctx, uint8_t *raw_reply, int raw_reply_length, uint8_t *raw_req)
+{
+    sft_t sft;
+    uint8_t req[MAX_MESSAGE_LENGTH];
+    int req_length;
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (raw_reply_length < 2 || raw_reply_length > (MODBUS_MAX_PDU_LENGTH + 1)) {
+        /* The raw request must contain function and slave at least and
+           must not be longer than the maximum pdu length plus the slave
+           address. */
+        errno = EINVAL;
+        return -1;
+    }
+
+    sft.slave = raw_reply[0];
+    sft.function = raw_reply[1];
+    /* If it uses TCP, copy t_id from request. 
+    The value of "req_length" is useless in this case */
+    sft.t_id = ctx->backend->prepare_response_tid(raw_req, 0);
+
+    /* This response function only set the header so it's convenient here */
+    req_length = ctx->backend->build_response_basis(&sft, req);
+
+    if (raw_reply_length > 2) {
+        /* Copy data after function code */
+        memcpy(req + req_length, raw_reply + 2, raw_reply_length - 2);
+        req_length += raw_reply_length - 2;
+    }
+
+    return send_msg(ctx, req, req_length);
+}
+
 /*
  *  ---------- Request     Indication ----------
  *  | Client | ---------------------->| Server |

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -214,6 +214,7 @@ MODBUS_API modbus_mapping_t* modbus_mapping_new(int nb_bits, int nb_input_bits,
 MODBUS_API void modbus_mapping_free(modbus_mapping_t *mb_mapping);
 
 MODBUS_API int modbus_send_raw_request(modbus_t *ctx, uint8_t *raw_req, int raw_req_length);
+MODBUS_API int modbus_send_raw_reply(modbus_t *ctx, uint8_t *raw_reply, int raw_reply_length, uint8_t *raw_req);
 
 MODBUS_API int modbus_receive(modbus_t *ctx, uint8_t *req);
 


### PR DESCRIPTION
modbus_send_raw_reply(4) creates a reply based on the client request. If it uses MODBUS TCP, it will generate the right TID for the reply. The uint8_t *raw_reply have to include all necessary data, from the slave ID and function code until the requested data.

It still lacks documentation and unit tests, but it is almost equal to modbus_send_raw_request(3), since the great change at the code is the generation of TID for TCP replies.
