### PR TITLE
Fixed can't specify serial ports larger than COM9 under Windows

### DIFF
--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -34,6 +34,8 @@
 #define ENOTSUP WSAEOPNOTSUPP
 #endif
 
+#define DEVICE_NAME_PREFIX  "\\\\.\\"
+
 /* WIN32: struct containing serial handle and a receive buffer */
 #define PY_BUF_SIZE 512
 struct win32_ser {

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -1158,9 +1158,16 @@ modbus_t* modbus_new_rtu(const char *device,
     ctx_rtu = (modbus_rtu_t *)ctx->backend_data;
     ctx_rtu->device = NULL;
 
+#if defined(_WIN32)
+    /* Device name and \0 */
+    ctx_rtu->device = (char *)malloc((strlen(DEVICE_NAME_PREFIX) + strlen(device) + 1) * sizeof(char));
+    strcpy(ctx_rtu->device, DEVICE_NAME_PREFIX);
+    strcat(ctx_rtu->device, device);
+#else
     /* Device name and \0 */
     ctx_rtu->device = (char *)malloc((strlen(device) + 1) * sizeof(char));
     strcpy(ctx_rtu->device, device);
+#endif
 
     ctx_rtu->baud = baud;
     if (parity == 'N' || parity == 'E' || parity == 'O') {


### PR DESCRIPTION
see https://support.microsoft.com/en-us/kb/115831