### PR TITLE
Fix building when byteswap.h is not defined

### DIFF
--- a/src/modbus-data.c
+++ b/src/modbus-data.c
@@ -37,9 +37,8 @@
 #endif
 #if defined(_MSC_VER) && (_MSC_VER >= 1400)
 # define bswap_32 _byteswap_ulong
+# define bswap_16 _byteswap_ushort
 #endif
-
-#if !defined(bswap_32)
 
 #if !defined(bswap_16)
 #   warning "Fallback on C functions for bswap_16"
@@ -49,6 +48,7 @@ static inline uint16_t bswap_16(uint16_t x)
 }
 #endif
 
+#if !defined(bswap_32)
 #   warning "Fallback on C functions for bswap_32"
 static inline uint32_t bswap_32(uint32_t x)
 {


### PR DESCRIPTION
Linking failed in Visual Studio due to unresolved bswap_16().