### PR TITLE
fix modbus connection lost after invalid function code

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1075,6 +1075,9 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
         break;
 
     default:
+        /* invalid function code -> flush rest of telegram */
+        _sleep_response_timeout(ctx);
+        modbus_flush(ctx);
         rsp_length = response_exception(ctx, &sft,
                                         MODBUS_EXCEPTION_ILLEGAL_FUNCTION,
                                         rsp);


### PR DESCRIPTION
Testcase:
* Client send function code (e.g. 24 read fifo) to master
* Client will lost connection
* Master will receive a ETIMEDOUT in modbus_receive_msg (backend->select) caused by data which wasn't read on illegal function access