### PR TITLE
Callback-API for modbus slaves

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,8 @@ libmodbus_la_SOURCES = \
         modbus-tcp.c \
         modbus-tcp.h \
         modbus-tcp-private.h \
-        modbus-version.h
+        modbus-version.h \
+		virtual-reply.c
 
 libmodbus_la_LDFLAGS = -no-undefined \
         -version-info $(LIBMODBUS_LT_VERSION_INFO)
@@ -35,7 +36,8 @@ endif
 
 # Header files to install
 libmodbusincludedir = $(includedir)/modbus
-libmodbusinclude_HEADERS = modbus.h modbus-version.h modbus-rtu.h modbus-tcp.h
+libmodbusinclude_HEADERS = modbus.h modbus-version.h modbus-rtu.h modbus-tcp.h \
+						   virtual-reply.h
 
 DISTCLEANFILES = modbus-version.h
 EXTRA_DIST += modbus-version.h.in

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -678,8 +678,7 @@ static int response_exception(modbus_t *ctx, sft_t *sft,
    accordingly.
 */
 int modbus_virt_reply(modbus_t *ctx, const uint8_t *req,
-                 int req_length, modbus_vmapping_t* vm,
-                 modbus_mapping_t *mb_mapping)
+                 int req_length, modbus_vmapping_t* vm)
 {
     int offset;
     int slave;
@@ -689,7 +688,7 @@ int modbus_virt_reply(modbus_t *ctx, const uint8_t *req,
     int rsp_length = 0;
     sft_t sft;
 
-    if ((ctx == NULL)||(vm==NULL)||(mb_mapping==NULL)||(req==NULL)) {
+    if ((ctx == NULL)||(vm==NULL)||(req==NULL)) {
         errno = EINVAL;
         return -1;
     }
@@ -777,7 +776,7 @@ int modbus_virt_reply(modbus_t *ctx, const uint8_t *req,
             if(!source) {
                 if (ctx->debug) {
                     fprintf(stderr, "Illegal data address 0x%0X in read_registers\n",
-                            address < mb_mapping->offset_registers ? address : address + nb);
+                            address);
                 }
                 rsp_length = response_exception(
                         ctx, &sft,
@@ -821,7 +820,7 @@ int modbus_virt_reply(modbus_t *ctx, const uint8_t *req,
             if(!source) {
                 if (ctx->debug) {
                     fprintf(stderr, "Illegal data address 0x%0X in read_input_registers\n",
-                            address < mb_mapping->offset_input_registers ? address : address + nb);
+                            address);
                 }
                 rsp_length = response_exception(
                         ctx, &sft,
@@ -1115,7 +1114,7 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
 {
     modbus_vmapping_t vm;
     modbus_virtualize_mapping(&vm, mb_mapping);
-    return modbus_virt_reply(ctx, req, req_length, &vm, mb_mapping);
+    return modbus_virt_reply(ctx, req, req_length, &vm);
 }
 
 int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -230,8 +230,7 @@ MODBUS_API int modbus_receive_confirmation(modbus_t *ctx, uint8_t *rsp);
 #include "virtual-reply.h"
 
 int modbus_virt_reply(modbus_t *ctx, const uint8_t *req,
-                 int req_length, modbus_vmapping_t *vm,
-                 modbus_mapping_t *mb_mapping);
+                 int req_length, modbus_vmapping_t *vm);
 MODBUS_API int modbus_reply(modbus_t *ctx, const uint8_t *req,
                             int req_length, modbus_mapping_t *mb_mapping);
 MODBUS_API int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -227,6 +227,11 @@ MODBUS_API int modbus_receive(modbus_t *ctx, uint8_t *req);
 
 MODBUS_API int modbus_receive_confirmation(modbus_t *ctx, uint8_t *rsp);
 
+#include "virtual-reply.h"
+
+int modbus_virt_reply(modbus_t *ctx, const uint8_t *req,
+                 int req_length, modbus_vmapping_t *vm,
+                 modbus_mapping_t *mb_mapping);
 MODBUS_API int modbus_reply(modbus_t *ctx, const uint8_t *req,
                             int req_length, modbus_mapping_t *mb_mapping);
 MODBUS_API int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,

--- a/src/virtual-reply.c
+++ b/src/virtual-reply.c
@@ -16,8 +16,10 @@ static uint8_t* get_bit_bucket(uint8_t *base, int address, int nb, int offset,
     return base + addr;
 }
 
-static uint8_t* get_discrete_inputs(void* app, int address, int nb)
+static uint8_t* get_discrete_inputs(void* app, int address, int nb,
+                                    modbus_vmap_reason reason)
 {
+    (void) reason;
     if(!app)
         return NULL;
 
@@ -27,8 +29,10 @@ static uint8_t* get_discrete_inputs(void* app, int address, int nb)
                           mb_mapping->nb_input_bits);
 }
 
-static uint8_t* get_coils(void* app, int address, int nb)
+static uint8_t* get_coils(void* app, int address, int nb,
+                          modbus_vmap_reason reason)
 {
+    (void) reason;
     if(!app)
         return NULL;
 
@@ -51,8 +55,10 @@ static uint16_t* get_specific_register(uint16_t *base, int address, int nb,
     return base + addr;
 }
 
-static uint16_t* get_register(void* app, int address, int nb)
+static uint16_t* get_register(void* app, int address, int nb,
+                              modbus_vmap_reason reason)
 {
+    (void) reason;
     if(!app)
         return NULL;
 
@@ -62,8 +68,10 @@ static uint16_t* get_register(void* app, int address, int nb)
                                  mb_mapping->nb_registers);
 }
 
-static uint16_t* get_input_register(void* app, int address, int nb)
+static uint16_t* get_input_register(void* app, int address, int nb,
+                                    modbus_vmap_reason reason)
 {
+    (void) reason;
     if(!app)
         return NULL;
 

--- a/src/virtual-reply.c
+++ b/src/virtual-reply.c
@@ -1,0 +1,11 @@
+#include "virtual-reply.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void modbus_virtualize_mapping(modbus_vmapping_t* dest,
+                               modbus_mapping_t* source)
+{
+    memset(dest, 0, sizeof(*dest));
+    dest->app = source;
+}

--- a/src/virtual-reply.c
+++ b/src/virtual-reply.c
@@ -1,11 +1,27 @@
-#include "virtual-reply.h"
+#include "modbus.h"
 
 #include <stdlib.h>
 #include <string.h>
+
+static uint8_t* get_discrete_inputs(void* app, int address, int nb)
+{
+    if(!app)
+        return NULL;
+
+    modbus_mapping_t* mb_mapping = app;
+    int addr = address - mb_mapping->offset_input_bits;
+    if (   (address < mb_mapping->offset_input_bits)
+        || ((addr + nb) > mb_mapping->nb_input_bits)) {
+        return NULL;
+    }
+    return mb_mapping->tab_input_bits + addr;
+}
+
 
 void modbus_virtualize_mapping(modbus_vmapping_t* dest,
                                modbus_mapping_t* source)
 {
     memset(dest, 0, sizeof(*dest));
     dest->app = source;
+    dest->tab_input_bits = get_discrete_inputs;
 }

--- a/src/virtual-reply.c
+++ b/src/virtual-reply.c
@@ -17,6 +17,20 @@ static uint8_t* get_discrete_inputs(void* app, int address, int nb)
     return mb_mapping->tab_input_bits + addr;
 }
 
+static uint8_t* get_coils(void* app, int address, int nb)
+{
+    if(!app)
+        return NULL;
+
+    modbus_mapping_t* mb_mapping = app;
+    int addr = address - mb_mapping->offset_bits;
+    if (   (address < mb_mapping->offset_bits)
+        || ((addr + nb) > mb_mapping->nb_bits)) {
+        return NULL;
+    }
+    return mb_mapping->tab_bits + addr;
+}
+
 
 void modbus_virtualize_mapping(modbus_vmapping_t* dest,
                                modbus_mapping_t* source)
@@ -24,4 +38,5 @@ void modbus_virtualize_mapping(modbus_vmapping_t* dest,
     memset(dest, 0, sizeof(*dest));
     dest->app = source;
     dest->tab_input_bits = get_discrete_inputs;
+    dest->tab_bits = get_coils;
 }

--- a/src/virtual-reply.c
+++ b/src/virtual-reply.c
@@ -38,6 +38,40 @@ static uint8_t* get_coils(void* app, int address, int nb)
                           mb_mapping->nb_bits);
 }
 
+static uint16_t* get_specific_register(uint16_t *base, int address, int nb,
+                                       int offset, int count)
+{
+    if(!base)
+        return NULL;
+
+    const int addr = address - offset;
+    if ((address < offset) || ((addr + nb) > count))
+        return NULL;
+
+    return base + addr;
+}
+
+static uint16_t* get_register(void* app, int address, int nb)
+{
+    if(!app)
+        return NULL;
+
+    modbus_mapping_t* mb_mapping = app;
+    return get_specific_register(mb_mapping->tab_registers, address, nb,
+                                 mb_mapping->offset_registers,
+                                 mb_mapping->nb_registers);
+}
+
+static uint16_t* get_input_register(void* app, int address, int nb)
+{
+    if(!app)
+        return NULL;
+
+    modbus_mapping_t* mb_mapping = app;
+    return get_specific_register(mb_mapping->tab_input_registers, address, nb,
+                                 mb_mapping->offset_input_registers,
+                                 mb_mapping->nb_input_registers);
+}
 
 void modbus_virtualize_mapping(modbus_vmapping_t* dest,
                                modbus_mapping_t* source)
@@ -46,4 +80,6 @@ void modbus_virtualize_mapping(modbus_vmapping_t* dest,
     dest->app = source;
     dest->tab_input_bits = get_discrete_inputs;
     dest->tab_bits = get_coils;
+    dest->tab_registers = get_register;
+    dest->tab_input_registers = get_input_register;
 }

--- a/src/virtual-reply.c
+++ b/src/virtual-reply.c
@@ -3,18 +3,28 @@
 #include <stdlib.h>
 #include <string.h>
 
+static uint8_t* get_bit_bucket(uint8_t *base, int address, int nb, int offset,
+                              int count)
+{
+    if(!base)
+        return NULL;
+
+    const int addr = address - offset;
+    if ((address < offset) || ((addr + nb) > count))
+        return NULL;
+
+    return base + addr;
+}
+
 static uint8_t* get_discrete_inputs(void* app, int address, int nb)
 {
     if(!app)
         return NULL;
 
     modbus_mapping_t* mb_mapping = app;
-    int addr = address - mb_mapping->offset_input_bits;
-    if (   (address < mb_mapping->offset_input_bits)
-        || ((addr + nb) > mb_mapping->nb_input_bits)) {
-        return NULL;
-    }
-    return mb_mapping->tab_input_bits + addr;
+    return get_bit_bucket(mb_mapping->tab_input_bits, address, nb,
+                          mb_mapping->offset_input_bits,
+                          mb_mapping->nb_input_bits);
 }
 
 static uint8_t* get_coils(void* app, int address, int nb)
@@ -23,12 +33,9 @@ static uint8_t* get_coils(void* app, int address, int nb)
         return NULL;
 
     modbus_mapping_t* mb_mapping = app;
-    int addr = address - mb_mapping->offset_bits;
-    if (   (address < mb_mapping->offset_bits)
-        || ((addr + nb) > mb_mapping->nb_bits)) {
-        return NULL;
-    }
-    return mb_mapping->tab_bits + addr;
+    return get_bit_bucket(mb_mapping->tab_bits, address, nb,
+                          mb_mapping->offset_bits,
+                          mb_mapping->nb_bits);
 }
 
 

--- a/src/virtual-reply.h
+++ b/src/virtual-reply.h
@@ -12,12 +12,33 @@
 #include "stdint.h"
 #endif
 
+typedef enum {
+    MODBUS_VMAP_READ,
+    MODBUS_VMAP_WRITE
+} modbus_vmap_reason;
+
 typedef struct {
     void* app;
-    uint8_t*  (*tab_bits)(void* app, int addr, int nb);
-    uint8_t*  (*tab_input_bits)(void* app, int addr, int nb);
-    uint16_t* (*tab_input_registers)(void* app, int addr, int nb);
-    uint16_t* (*tab_registers)(void* app, int addr, int nb);
+    uint8_t*  (*tab_bits)(void* app, int addr, int nb,
+                          modbus_vmap_reason what);
+    void (*tab_bits_done)(void* app, uint8_t* store, int addr, int nb,
+                          modbus_vmap_reason what);
+
+    uint8_t*  (*tab_input_bits)(void* app, int addr, int nb,
+                                modbus_vmap_reason what);
+    void (*tab_input_bits_done)(void* app, uint8_t* store, int addr, int nb,
+                                modbus_vmap_reason what);
+
+    uint16_t* (*tab_input_registers)(void* app, int addr, int nb,
+                                     modbus_vmap_reason what);
+    void (*tab_input_registers_done)(void* app, uint16_t*store, int addr,
+                                     int nb, modbus_vmap_reason what);
+
+
+    uint16_t* (*tab_registers)(void* app, int addr, int nb,
+                               modbus_vmap_reason what);
+    void (*tab_registers_done)(void* app, uint16_t* store, int addr, int nb,
+                               modbus_vmap_reason what);
 } modbus_vmapping_t;
 
 void modbus_virtualize_mapping(modbus_vmapping_t* dest,

--- a/src/virtual-reply.h
+++ b/src/virtual-reply.h
@@ -6,8 +6,6 @@
 #ifndef MODBUS_VIRTUAL_RESPONSE_H
 #define MODBUS_VIRTUAL_RESPONSE_H
 
-#include "modbus.h"
-
 #ifndef _MSC_VER
 #include <stdint.h>
 #else

--- a/src/virtual-reply.h
+++ b/src/virtual-reply.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2001-2013 Rüdiger Ranft <libmodbus@qzzq.de>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+#ifndef MODBUS_VIRTUAL_RESPONSE_H
+#define MODBUS_VIRTUAL_RESPONSE_H
+
+#include "modbus.h"
+
+#ifndef _MSC_VER
+#include <stdint.h>
+#else
+#include "stdint.h"
+#endif
+
+typedef struct {
+    void* app;
+    uint8_t*  (*tab_bits)(void* app, int addr, int nb);
+    uint8_t*  (*tab_input_bits)(void* app, int addr, int nb);
+    uint16_t* (*tab_input_registers)(void* app, int addr, int nb);
+    uint16_t* (*tab_registers)(void* app, int addr, int nb);
+} modbus_vmapping_t;
+
+void modbus_virtualize_mapping(modbus_vmapping_t* dest,
+                               modbus_mapping_t* source);
+
+#endif


### PR DESCRIPTION
The `modbus_reply`-function was changed to support callbacks instead of a memory mapping. The memory mapping is now a specialized case of the callback mechanism, in order to handle both cases the same way (= no copies of existing code).
