### PR TITLE
Fixing LIBMODBUS_VERSION_HEX encoding

### DIFF
--- a/src/modbus-version.h.in
+++ b/src/modbus-version.h.in
@@ -36,9 +36,9 @@
 #define LIBMODBUS_VERSION_STRING "@LIBMODBUS_VERSION@"
 
 /* Numerically encoded version, like 0x010203 */
-#define LIBMODBUS_VERSION_HEX ((LIBMODBUS_VERSION_MAJOR << 24) |  \
-                               (LIBMODBUS_VERSION_MINOR << 16) |  \
-                               (LIBMODBUS_VERSION_MICRO << 8))
+#define LIBMODBUS_VERSION_HEX ((LIBMODBUS_VERSION_MAJOR << 16) |  \
+                               (LIBMODBUS_VERSION_MINOR <<  8) |  \
+                               (LIBMODBUS_VERSION_MICRO <<  0))
 
 /* Evaluates to True if the version is greater than @major, @minor and @micro
  */


### PR DESCRIPTION
The given definition for LIBMODBUS_VERSION_HEX is not coherent with the result given by the macro itself, which is left-shifted by an extra factor of 8 bits.

For example, current implementation for version 1.2.3 would be encoded like 0x01020300 instead of 0x010203.

You can either accept this pull request (breaking change here if someone did rely on this macro!!) or update the commented definition.