### PR TITLE
Allow usage of alternative log facilities

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 #
 m4_define([libmodbus_version_major], [3])
 m4_define([libmodbus_version_minor], [1])
-m4_define([libmodbus_version_micro], [4])
+m4_define([libmodbus_version_micro], [5])
 
 m4_define([libmodbus_release_status],
     [m4_if(m4_eval(libmodbus_version_minor % 2), [1], [snapshot], [release])])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,6 +14,8 @@ libmodbus_la_SOURCES = \
         modbus.h \
         modbus-data.c \
         modbus-private.h \
+        modbus-log.c \
+        modbus-log.h \
         modbus-rtu.c \
         modbus-rtu.h \
         modbus-rtu-private.h \
@@ -35,7 +37,7 @@ endif
 
 # Header files to install
 libmodbusincludedir = $(includedir)/modbus
-libmodbusinclude_HEADERS = modbus.h modbus-version.h modbus-rtu.h modbus-tcp.h
+libmodbusinclude_HEADERS = modbus.h modbus-version.h modbus-log.h modbus-rtu.h modbus-tcp.h
 
 DISTCLEANFILES = modbus-version.h
 EXTRA_DIST += modbus-version.h.in

--- a/src/modbus-log.c
+++ b/src/modbus-log.c
@@ -1,0 +1,63 @@
+#include "modbus-log.h"
+
+#include <stdio.h>
+#include <stddef.h>
+
+static void* modbus_out_user_data = NULL;
+static void* modbus_error_user_data = NULL;
+static modbus_stream_handler_t modbus_stream_handler = (modbus_stream_handler_t) vfprintf;
+
+MODBUS_API void modbus_set_out_user_data(void* out_user_data)
+{
+    modbus_out_user_data = out_user_data;
+}
+
+MODBUS_API void modbus_set_error_user_data(void* error_user_data)
+{
+    modbus_error_user_data = error_user_data;
+}
+
+MODBUS_API void modbus_set_trace_handler(modbus_stream_handler_t handler)
+{
+    modbus_stream_handler = handler;
+}
+
+MODBUS_API int modbus_trace(const char* format, ...)
+{
+    int result;
+    va_list argp;
+    va_start(argp, format);
+
+    result = modbus_vtrace(format, argp);
+
+    va_end(argp);
+    return result;
+}
+
+MODBUS_API int modbus_vtrace(const char* format, va_list ap)
+{
+    if (!modbus_out_user_data) {
+        modbus_out_user_data = stdout;
+    }
+    return modbus_stream_handler(modbus_out_user_data, format, ap);
+}
+
+MODBUS_API int modbus_trace_error(const char* format, ...)
+{
+    int result;
+    va_list argp;
+    va_start(argp, format);
+
+    result = modbus_vtrace_error(format, argp);
+
+    va_end(argp);
+    return result;
+}
+
+MODBUS_API int modbus_vtrace_error(const char* format, va_list ap)
+{
+    if (!modbus_error_user_data) {
+        modbus_error_user_data = stderr;
+    }
+    return modbus_stream_handler(modbus_error_user_data, format, ap);
+}

--- a/src/modbus-log.h
+++ b/src/modbus-log.h
@@ -1,0 +1,19 @@
+#ifndef MODBUS_LOG_H
+#define MODBUS_LOG_H
+
+#include "modbus.h"
+
+#include <stdarg.h>
+
+MODBUS_API void modbus_set_out_user_data(void* out_user_data);
+MODBUS_API void modbus_set_error_user_data(void* error_user_data);
+
+typedef int (*modbus_stream_handler_t)(void *user, const char *format, va_list ap);
+MODBUS_API void modbus_set_trace_handler(modbus_stream_handler_t handler);
+
+MODBUS_API int modbus_trace(const char* format, ...);
+MODBUS_API int modbus_vtrace(const char* format, va_list ap);
+MODBUS_API int modbus_trace_error(const char* format, ...);
+MODBUS_API int modbus_vtrace_error(const char* format, va_list ap);
+
+#endif /* MODBUS_LOG_H */

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -280,7 +280,7 @@ static ssize_t _modbus_rtu_send(modbus_t *ctx, const uint8_t *req, int req_lengt
         ssize_t size;
 
         if (ctx->debug) {
-            fprintf(stderr, "Sending request using RTS signal\n");
+            modbus_trace_error("Sending request using RTS signal\n");
         }
 
         ctx_rtu->set_rts(ctx, ctx_rtu->rts == MODBUS_RTU_RTS_UP);
@@ -312,7 +312,7 @@ static int _modbus_rtu_receive(modbus_t *ctx, uint8_t *req)
         ctx_rtu->confirmation_to_ignore = FALSE;
         rc = 0;
         if (ctx->debug) {
-            printf("Confirmation to ignore\n");
+            modbus_trace("Confirmation to ignore\n");
         }
     } else {
         rc = _modbus_receive_msg(ctx, req, MSG_INDICATION);
@@ -342,7 +342,7 @@ static int _modbus_rtu_pre_check_confirmation(modbus_t *ctx, const uint8_t *req,
      * request) */
     if (req[0] != rsp[0] && req[0] != MODBUS_BROADCAST_ADDRESS) {
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "The responding slave %d isn't the requested slave %d\n",
                     rsp[0], req[0]);
         }
@@ -367,7 +367,7 @@ static int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
      * CRC computing. */
     if (slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS) {
         if (ctx->debug) {
-            printf("Request for slave %d ignored (not %d)\n", slave, ctx->slave);
+            modbus_trace("Request for slave %d ignored (not %d)\n", slave, ctx->slave);
         }
         /* Following call to check_confirmation handles this error */
         return 0;
@@ -381,7 +381,7 @@ static int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
         return msg_length;
     } else {
         if (ctx->debug) {
-            fprintf(stderr, "ERROR CRC received 0x%0X != CRC calculated 0x%0X\n",
+            modbus_trace_error("ERROR CRC received 0x%0X != CRC calculated 0x%0X\n",
                     crc_received, crc_calculated);
         }
 
@@ -406,7 +406,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     modbus_rtu_t *ctx_rtu = ctx->backend_data;
 
     if (ctx->debug) {
-        printf("Opening %s at %d bauds (%c, %d, %d)\n",
+        modbus_trace("Opening %s at %d bauds (%c, %d, %d)\n",
                ctx_rtu->device, ctx_rtu->baud, ctx_rtu->parity,
                ctx_rtu->data_bit, ctx_rtu->stop_bit);
     }
@@ -430,7 +430,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     /* Error checking */
     if (ctx_rtu->w_ser.fd == INVALID_HANDLE_VALUE) {
         if (ctx->debug) {
-            fprintf(stderr, "ERROR Can't open the device %s (LastError %d)\n",
+            modbus_trace_error("ERROR Can't open the device %s (LastError %d)\n",
                     ctx_rtu->device, (int)GetLastError());
         }
         return -1;
@@ -440,7 +440,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     ctx_rtu->old_dcb.DCBlength = sizeof(DCB);
     if (!GetCommState(ctx_rtu->w_ser.fd, &ctx_rtu->old_dcb)) {
         if (ctx->debug) {
-            fprintf(stderr, "ERROR Error getting configuration (LastError %d)\n",
+            modbus_trace_error("ERROR Error getting configuration (LastError %d)\n",
                     (int)GetLastError());
         }
         CloseHandle(ctx_rtu->w_ser.fd);
@@ -511,7 +511,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     default:
         dcb.BaudRate = CBR_9600;
         if (ctx->debug) {
-            fprintf(stderr, "WARNING Unknown baud rate %d for %s (B9600 used)\n",
+            modbus_trace_error("WARNING Unknown baud rate %d for %s (B9600 used)\n",
                     ctx_rtu->baud, ctx_rtu->device);
         }
     }
@@ -568,7 +568,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     /* Setup port */
     if (!SetCommState(ctx_rtu->w_ser.fd, &dcb)) {
         if (ctx->debug) {
-            fprintf(stderr, "ERROR Error setting new configuration (LastError %d)\n",
+            modbus_trace_error("ERROR Error setting new configuration (LastError %d)\n",
                     (int)GetLastError());
         }
         CloseHandle(ctx_rtu->w_ser.fd);
@@ -591,7 +591,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     ctx->s = open(ctx_rtu->device, flags);
     if (ctx->s == -1) {
         if (ctx->debug) {
-            fprintf(stderr, "ERROR Can't open the device %s (%s)\n",
+            modbus_trace_error("ERROR Can't open the device %s (%s)\n",
                     ctx_rtu->device, strerror(errno));
         }
         return -1;
@@ -706,7 +706,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     default:
         speed = B9600;
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "WARNING Unknown baud rate %d for %s (B9600 used)\n",
                     ctx_rtu->baud, ctx_rtu->device);
         }
@@ -932,7 +932,7 @@ int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode)
         }
 #else
         if (ctx->debug) {
-            fprintf(stderr, "This function isn't supported on your platform\n");
+            modbus_trace_error("This function isn't supported on your platform\n");
         }
         errno = ENOTSUP;
         return -1;
@@ -957,7 +957,7 @@ int modbus_rtu_get_serial_mode(modbus_t *ctx)
         return ctx_rtu->serial_mode;
 #else
         if (ctx->debug) {
-            fprintf(stderr, "This function isn't supported on your platform\n");
+            modbus_trace_error("This function isn't supported on your platform\n");
         }
         errno = ENOTSUP;
         return -1;
@@ -981,7 +981,7 @@ int modbus_rtu_get_rts(modbus_t *ctx)
         return ctx_rtu->rts;
 #else
         if (ctx->debug) {
-            fprintf(stderr, "This function isn't supported on your platform\n");
+            modbus_trace_error("This function isn't supported on your platform\n");
         }
         errno = ENOTSUP;
         return -1;
@@ -1017,7 +1017,7 @@ int modbus_rtu_set_rts(modbus_t *ctx, int mode)
         }
 #else
         if (ctx->debug) {
-            fprintf(stderr, "This function isn't supported on your platform\n");
+            modbus_trace_error("This function isn't supported on your platform\n");
         }
         errno = ENOTSUP;
         return -1;
@@ -1042,7 +1042,7 @@ int modbus_rtu_set_custom_rts(modbus_t *ctx, void (*set_rts) (modbus_t *ctx, int
         return 0;
 #else
         if (ctx->debug) {
-            fprintf(stderr, "This function isn't supported on your platform\n");
+            modbus_trace_error("This function isn't supported on your platform\n");
         }
         errno = ENOTSUP;
         return -1;
@@ -1067,7 +1067,7 @@ int modbus_rtu_get_rts_delay(modbus_t *ctx)
         return ctx_rtu->rts_delay;
 #else
         if (ctx->debug) {
-            fprintf(stderr, "This function isn't supported on your platform\n");
+            modbus_trace_error("This function isn't supported on your platform\n");
         }
         errno = ENOTSUP;
         return -1;
@@ -1093,7 +1093,7 @@ int modbus_rtu_set_rts_delay(modbus_t *ctx, int us)
         return 0;
 #else
         if (ctx->debug) {
-            fprintf(stderr, "This function isn't supported on your platform\n");
+            modbus_trace_error("This function isn't supported on your platform\n");
         }
         errno = ENOTSUP;
         return -1;
@@ -1112,12 +1112,12 @@ static void _modbus_rtu_close(modbus_t *ctx)
 #if defined(_WIN32)
     /* Revert settings */
     if (!SetCommState(ctx_rtu->w_ser.fd, &ctx_rtu->old_dcb) && ctx->debug) {
-        fprintf(stderr, "ERROR Couldn't revert to configuration (LastError %d)\n",
+        modbus_trace_error("ERROR Couldn't revert to configuration (LastError %d)\n",
                 (int)GetLastError());
     }
 
     if (!CloseHandle(ctx_rtu->w_ser.fd) && ctx->debug) {
-        fprintf(stderr, "ERROR Error while closing handle (LastError %d)\n",
+        modbus_trace_error("ERROR Error while closing handle (LastError %d)\n",
                 (int)GetLastError());
     }
 #else
@@ -1159,7 +1159,7 @@ static int _modbus_rtu_select(modbus_t *ctx, fd_set *rset,
     while ((s_rc = select(ctx->s+1, rset, NULL, NULL, tv)) == -1) {
         if (errno == EINTR) {
             if (ctx->debug) {
-                fprintf(stderr, "A non blocked signal was caught\n");
+                modbus_trace_error("A non blocked signal was caught\n");
             }
             /* Necessary after an error */
             FD_ZERO(rset);
@@ -1216,14 +1216,14 @@ modbus_t* modbus_new_rtu(const char *device,
 
     /* Check device argument */
     if (device == NULL || *device == 0) {
-        fprintf(stderr, "The device string is empty\n");
+        modbus_trace_error("The device string is empty\n");
         errno = EINVAL;
         return NULL;
     }
 
     /* Check baud argument */
     if (baud == 0) {
-        fprintf(stderr, "The baud rate value must not be zero\n");
+        modbus_trace_error("The baud rate value must not be zero\n");
         errno = EINVAL;
         return NULL;
     }

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -65,7 +65,7 @@ static int _modbus_tcp_init_win32(void)
     WSADATA wsaData;
 
     if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
-        fprintf(stderr, "WSAStartup() returned error code %d\n",
+        modbus_trace_error("WSAStartup() returned error code %d\n",
                 (unsigned int)GetLastError());
         errno = EIO;
         return -1;
@@ -191,7 +191,7 @@ static int _modbus_tcp_pre_check_confirmation(modbus_t *ctx, const uint8_t *req,
     /* Check transaction ID */
     if (req[0] != rsp[0] || req[1] != rsp[1]) {
         if (ctx->debug) {
-            fprintf(stderr, "Invalid transaction ID received 0x%X (not 0x%X)\n",
+            modbus_trace_error("Invalid transaction ID received 0x%X (not 0x%X)\n",
                     (rsp[0] << 8) + rsp[1], (req[0] << 8) + req[1]);
         }
         errno = EMBBADDATA;
@@ -201,7 +201,7 @@ static int _modbus_tcp_pre_check_confirmation(modbus_t *ctx, const uint8_t *req,
     /* Check protocol ID */
     if (rsp[2] != 0x0 && rsp[3] != 0x0) {
         if (ctx->debug) {
-            fprintf(stderr, "Invalid protocol ID received 0x%X (not 0x0)\n",
+            modbus_trace_error("Invalid protocol ID received 0x%X (not 0x0)\n",
                     (rsp[2] << 8) + rsp[3]);
         }
         errno = EMBBADDATA;
@@ -335,7 +335,7 @@ static int _modbus_tcp_connect(modbus_t *ctx)
     }
 
     if (ctx->debug) {
-        printf("Connecting to %s:%d\n", ctx_tcp->ip, ctx_tcp->port);
+        modbus_trace("Connecting to %s:%d\n", ctx_tcp->ip, ctx_tcp->port);
     }
 
     addr.sin_family = AF_INET;
@@ -381,7 +381,7 @@ static int _modbus_tcp_pi_connect(modbus_t *ctx)
                      &ai_hints, &ai_list);
     if (rc != 0) {
         if (ctx->debug) {
-            fprintf(stderr, "Error returned by getaddrinfo: %s\n", gai_strerror(rc));
+            modbus_trace_error("Error returned by getaddrinfo: %s\n", gai_strerror(rc));
         }
         errno = ECONNREFUSED;
         return -1;
@@ -407,7 +407,7 @@ static int _modbus_tcp_pi_connect(modbus_t *ctx)
             _modbus_tcp_set_ipv4_options(s);
 
         if (ctx->debug) {
-            printf("Connecting to [%s]:%s\n", ctx_tcp_pi->node, ctx_tcp_pi->service);
+            modbus_trace("Connecting to [%s]:%s\n", ctx_tcp_pi->node, ctx_tcp_pi->service);
         }
 
         rc = _connect(s, ai_ptr->ai_addr, ai_ptr->ai_addrlen, &ctx->response_timeout);
@@ -585,7 +585,7 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
     rc = getaddrinfo(node, service, &ai_hints, &ai_list);
     if (rc != 0) {
         if (ctx->debug) {
-            fprintf(stderr, "Error returned by getaddrinfo: %s\n", gai_strerror(rc));
+            modbus_trace_error("Error returned by getaddrinfo: %s\n", gai_strerror(rc));
         }
         errno = ECONNREFUSED;
         return -1;
@@ -668,7 +668,7 @@ int modbus_tcp_accept(modbus_t *ctx, int *s)
     }
 
     if (ctx->debug) {
-        printf("The client connection from %s is accepted\n",
+        modbus_trace("The client connection from %s is accepted\n",
                inet_ntoa(addr.sin_addr));
     }
 
@@ -698,7 +698,7 @@ int modbus_tcp_pi_accept(modbus_t *ctx, int *s)
     }
 
     if (ctx->debug) {
-        printf("The client connection is accepted.\n");
+        modbus_trace("The client connection is accepted.\n");
     }
 
     return ctx->s;
@@ -710,7 +710,7 @@ static int _modbus_tcp_select(modbus_t *ctx, fd_set *rset, struct timeval *tv, i
     while ((s_rc = select(ctx->s+1, rset, NULL, NULL, tv)) == -1) {
         if (errno == EINTR) {
             if (ctx->debug) {
-                fprintf(stderr, "A non blocked signal was caught\n");
+                modbus_trace_error("A non blocked signal was caught\n");
             }
             /* Necessary after an error */
             FD_ZERO(rset);
@@ -793,7 +793,7 @@ modbus_t* modbus_new_tcp(const char *ip, int port)
     sa.sa_handler = SIG_IGN;
     if (sigaction(SIGPIPE, &sa, NULL) < 0) {
         /* The debug flag can't be set here... */
-        fprintf(stderr, "Coud not install SIGPIPE handler.\n");
+        modbus_trace_error("Coud not install SIGPIPE handler.\n");
         return NULL;
     }
 #endif
@@ -813,14 +813,14 @@ modbus_t* modbus_new_tcp(const char *ip, int port)
         dest_size = sizeof(char) * 16;
         ret_size = strlcpy(ctx_tcp->ip, ip, dest_size);
         if (ret_size == 0) {
-            fprintf(stderr, "The IP string is empty\n");
+            modbus_trace_error("The IP string is empty\n");
             modbus_free(ctx);
             errno = EINVAL;
             return NULL;
         }
 
         if (ret_size >= dest_size) {
-            fprintf(stderr, "The IP string has been truncated\n");
+            modbus_trace_error("The IP string has been truncated\n");
             modbus_free(ctx);
             errno = EINVAL;
             return NULL;
@@ -860,14 +860,14 @@ modbus_t* modbus_new_tcp_pi(const char *node, const char *service)
         dest_size = sizeof(char) * _MODBUS_TCP_PI_NODE_LENGTH;
         ret_size = strlcpy(ctx_tcp_pi->node, node, dest_size);
         if (ret_size == 0) {
-            fprintf(stderr, "The node string is empty\n");
+            modbus_trace_error("The node string is empty\n");
             modbus_free(ctx);
             errno = EINVAL;
             return NULL;
         }
 
         if (ret_size >= dest_size) {
-            fprintf(stderr, "The node string has been truncated\n");
+            modbus_trace_error("The node string has been truncated\n");
             modbus_free(ctx);
             errno = EINVAL;
             return NULL;
@@ -883,14 +883,14 @@ modbus_t* modbus_new_tcp_pi(const char *node, const char *service)
     }
 
     if (ret_size == 0) {
-        fprintf(stderr, "The service string is empty\n");
+        modbus_trace_error("The service string is empty\n");
         modbus_free(ctx);
         errno = EINVAL;
         return NULL;
     }
 
     if (ret_size >= dest_size) {
-        fprintf(stderr, "The service string has been truncated\n");
+        modbus_trace_error("The service string has been truncated\n");
         modbus_free(ctx);
         errno = EINVAL;
         return NULL;

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -81,11 +81,11 @@ const char *modbus_strerror(int errnum) {
 void _error_print(modbus_t *ctx, const char *context)
 {
     if (ctx->debug) {
-        fprintf(stderr, "ERROR %s", modbus_strerror(errno));
+        modbus_trace_error("ERROR %s", modbus_strerror(errno));
         if (context != NULL) {
-            fprintf(stderr, ": %s\n", context);
+            modbus_trace_error(": %s\n", context);
         } else {
-            fprintf(stderr, "\n");
+            modbus_trace_error("\n");
         }
     }
 }
@@ -120,7 +120,7 @@ int modbus_flush(modbus_t *ctx)
     rc = ctx->backend->flush(ctx);
     if (rc != -1 && ctx->debug) {
         /* Not all backends are able to return the number of bytes flushed */
-        printf("Bytes flushed (%d)\n", rc);
+        modbus_trace("Bytes flushed (%d)\n", rc);
     }
     return rc;
 }
@@ -172,8 +172,8 @@ static int send_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
 
     if (ctx->debug) {
         for (i = 0; i < msg_length; i++)
-            printf("[%.2X]", msg[i]);
-        printf("\n");
+            modbus_trace("[%.2X]", msg[i]);
+        modbus_trace("\n");
     }
 
     /* In recovery mode, the write command will be issued until to be
@@ -349,9 +349,9 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
 
     if (ctx->debug) {
         if (msg_type == MSG_INDICATION) {
-            printf("Waiting for a indication...\n");
+            modbus_trace("Waiting for a indication...\n");
         } else {
-            printf("Waiting for a confirmation...\n");
+            modbus_trace("Waiting for a confirmation...\n");
         }
     }
 
@@ -418,7 +418,7 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
         if (ctx->debug) {
             int i;
             for (i=0; i < rc; i++)
-                printf("<%.2X>", msg[msg_length + i]);
+                modbus_trace("<%.2X>", msg[msg_length + i]);
         }
 
         /* Sums bytes received */
@@ -466,7 +466,7 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
     }
 
     if (ctx->debug)
-        printf("\n");
+        modbus_trace("\n");
 
     return ctx->backend->check_integrity(ctx, msg, msg_length);
 }
@@ -552,7 +552,7 @@ static int check_confirmation(modbus_t *ctx, uint8_t *req,
         /* Check function code */
         if (function != req[offset]) {
             if (ctx->debug) {
-                fprintf(stderr,
+                modbus_trace_error(
                         "Received function not corresponding to the request (0x%X != 0x%X)\n",
                         function, req[offset]);
             }
@@ -601,7 +601,7 @@ static int check_confirmation(modbus_t *ctx, uint8_t *req,
             rc = rsp_nb_value;
         } else {
             if (ctx->debug) {
-                fprintf(stderr,
+                modbus_trace_error(
                         "Quantity not corresponding to the request (%d != %d)\n",
                         rsp_nb_value, req_nb_value);
             }
@@ -616,7 +616,7 @@ static int check_confirmation(modbus_t *ctx, uint8_t *req,
         }
     } else {
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "Message length not corresponding to the computed length (%d != %d)\n",
                     rsp_length, rsp_length_computed);
         }
@@ -670,7 +670,7 @@ static int response_exception(modbus_t *ctx, sft_t *sft,
         va_list ap;
 
         va_start(ap, template);
-        vfprintf(stderr, template, ap);
+        modbus_vtrace_error(template, ap);
         va_end(ap);
     }
 
@@ -909,7 +909,7 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
         break;
     case MODBUS_FC_READ_EXCEPTION_STATUS:
         if (ctx->debug) {
-            fprintf(stderr, "FIXME Not implemented\n");
+            modbus_trace_error("FIXME Not implemented\n");
         }
         errno = ENOPROTOOPT;
         return -1;
@@ -1083,7 +1083,7 @@ int modbus_read_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest)
 
     if (nb > MODBUS_MAX_READ_BITS) {
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "ERROR Too many bits requested (%d > %d)\n",
                     nb, MODBUS_MAX_READ_BITS);
         }
@@ -1112,7 +1112,7 @@ int modbus_read_input_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest)
 
     if (nb > MODBUS_MAX_READ_BITS) {
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "ERROR Too many discrete inputs requested (%d > %d)\n",
                     nb, MODBUS_MAX_READ_BITS);
         }
@@ -1139,7 +1139,7 @@ static int read_registers(modbus_t *ctx, int function, int addr, int nb,
 
     if (nb > MODBUS_MAX_READ_REGISTERS) {
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "ERROR Too many registers requested (%d > %d)\n",
                     nb, MODBUS_MAX_READ_REGISTERS);
         }
@@ -1187,7 +1187,7 @@ int modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t *dest)
 
     if (nb > MODBUS_MAX_READ_REGISTERS) {
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "ERROR Too many registers requested (%d > %d)\n",
                     nb, MODBUS_MAX_READ_REGISTERS);
         }
@@ -1212,7 +1212,7 @@ int modbus_read_input_registers(modbus_t *ctx, int addr, int nb,
     }
 
     if (nb > MODBUS_MAX_READ_REGISTERS) {
-        fprintf(stderr,
+        modbus_trace_error(
                 "ERROR Too many input registers requested (%d > %d)\n",
                 nb, MODBUS_MAX_READ_REGISTERS);
         errno = EMBMDATA;
@@ -1296,7 +1296,7 @@ int modbus_write_bits(modbus_t *ctx, int addr, int nb, const uint8_t *src)
 
     if (nb > MODBUS_MAX_WRITE_BITS) {
         if (ctx->debug) {
-            fprintf(stderr, "ERROR Writing too many bits (%d > %d)\n",
+            modbus_trace_error("ERROR Writing too many bits (%d > %d)\n",
                     nb, MODBUS_MAX_WRITE_BITS);
         }
         errno = EMBMDATA;
@@ -1357,7 +1357,7 @@ int modbus_write_registers(modbus_t *ctx, int addr, int nb, const uint16_t *src)
 
     if (nb > MODBUS_MAX_WRITE_REGISTERS) {
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "ERROR Trying to write to too many registers (%d > %d)\n",
                     nb, MODBUS_MAX_WRITE_REGISTERS);
         }
@@ -1449,7 +1449,7 @@ int modbus_write_and_read_registers(modbus_t *ctx,
 
     if (write_nb > MODBUS_MAX_WR_WRITE_REGISTERS) {
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "ERROR Too many registers to write (%d > %d)\n",
                     write_nb, MODBUS_MAX_WR_WRITE_REGISTERS);
         }
@@ -1459,7 +1459,7 @@ int modbus_write_and_read_registers(modbus_t *ctx,
 
     if (read_nb > MODBUS_MAX_WR_READ_REGISTERS) {
         if (ctx->debug) {
-            fprintf(stderr,
+            modbus_trace_error(
                     "ERROR Too many registers requested (%d > %d)\n",
                     read_nb, MODBUS_MAX_WR_READ_REGISTERS);
         }

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -285,6 +285,8 @@ MODBUS_API void modbus_set_float_cdab(float f, uint16_t *dest);
 #include "modbus-tcp.h"
 #include "modbus-rtu.h"
 
+#include "modbus-log.h"
+
 MODBUS_END_DECLS
 
 #endif  /* MODBUS_H */


### PR DESCRIPTION
This allows to override ```printf()``` and ```fprintf(stderr, ...)``` externally. This way, users of this library can use log facilities such as ```syslog()``` or user-defined wrappers. 

I am not sure about the version number change.
