### PR TITLE
Fix of modbus.vcproj + AppVeyor Windows CI / Binaries Support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,6 +52,7 @@ test_script:
   - ps: >-
       if($env:PLATFORM -like "cygwin*") {
         cd $env:APPVEYOR_BUILD_FOLDER
+        $ErrorActionPreference = "Stop"
         bash -c 'make check'
         echo "check was run"
       }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,24 +1,85 @@
-## Operating System (VM environment) ##
-platform: x64
-image: Visual Studio 2017
+version: 3.1.6-{build}
 
-## Install Script ##
-install:
-  - set CYGWIN_ROOT=C:\cygwin64
-  - set PATH=%CYGWIN_ROOT%\bin;%PATH%
-  - bash --version
-  - bash -c 'autoreconf --version'
-  - bash -c 'make --version'
+image:
+  - Visual Studio 2013
+  - Visual Studio 2017
 
-## Disable MSBuild (default) ##
-build: off
+clone_depth: 1
 
-## Build Script ##
+before_build:
+  - ps: >-
+      if($env:PLATFORM -like "cygwin*") {
+        $env:CYGWIN_ROOT="C:\$env:PLATFORM"
+        $env:PATH="$env:CYGWIN_ROOT\bin;$env:PATH"
+      } else {
+        cd C:\projects\libmodbus\src\win32
+        cscript.exe configure.js
+        curl https://raw.githubusercontent.com/chemeris/msinttypes/master/stdint.h -o ..\stdint.h
+      }
+
+platform:
+  - Win32
+  - x64
+  - cygwin
+  - cygwin64
+
+matrix:
+  exclude:
+    - image: Visual Studio 2013
+      platform: cygwin
+    - image: Visual Studio 2013
+      platform: cygwin64
+    - image: Visual Studio 2017
+      platform: Win32
+    - image: Visual Studio 2017
+      platform: x64
+
+configuration: Release
+
 build_script:
-  - bash autogen.sh
-  - bash configure
-  - bash -c 'make'
+  - ps: >-
+      if($env:PLATFORM -like "cygwin*") {
+        cd $env:APPVEYOR_BUILD_FOLDER
+        bash autogen.sh
+        bash configure
+        bash -c 'make'
+      } else {
+        cd $env:APPVEYOR_BUILD_FOLDER\src\win32
+        C:\WINDOWS\Microsoft.NET\Framework\v3.5\msbuild.exe "$env:APPVEYOR_BUILD_FOLDER\src\win32\modbus.vcproj" "/p:Configuration=$env:CONFIGURATION" "/p:Platform=$env:PLATFORM"
+      }
 
-## Test Script ##
 test_script:
-  - bash -c 'make check'
+  - ps: >-
+      if($env:PLATFORM -like "cygwin*") {
+        cd $env:APPVEYOR_BUILD_FOLDER
+        bash -c 'make check'
+        echo "check was run"
+      }
+
+after_build:
+  - ps: >-
+      if($true) {
+        cd $env:APPVEYOR_BUILD_FOLDER\src
+        mkdir ..\archive
+        copy modbus.h ..\archive
+        copy modbus-version.h ..\archive
+        copy modbus-tcp.h ..\archive
+        copy modbus-rtu.h ..\archive
+        if($env:PLATFORM -like "cygwin*") {
+          copy .\.libs\cygmodbus-5.dll ..\archive
+          copy .\.libs\libmodbus.dll.a ..\archive
+          copy .\.libs\libmodbus.lai ..\archive\libmodbus.la
+        } else {
+          copy stdint.h ..\archive
+          copy "win32\$env:PLATFORM\$env:CONFIGURATION\modbus.dll" ..\archive
+          copy "win32\$env:PLATFORM\$env:CONFIGURATION\modbus.exp" ..\archive
+          copy "win32\$env:PLATFORM\$env:CONFIGURATION\modbus.lib" ..\archive
+          copy "win32\$env:PLATFORM\$env:CONFIGURATION\modbus.pdb" ..\archive
+        }
+        cd ..\archive
+        $artifactName = "modbus_" + $env:PLATFORM.ToLower() + ".zip"
+        7z a ..\$artifactName *
+      }
+
+artifacts:
+  - path: '*.zip'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ before_build:
         $env:CYGWIN_ROOT="C:\$env:PLATFORM"
         $env:PATH="$env:CYGWIN_ROOT\bin;$env:PATH"
       } else {
-        cd C:\projects\libmodbus\src\win32
+        cd $env:APPVEYOR_BUILD_FOLDER\src\win32
         cscript.exe configure.js
         curl https://raw.githubusercontent.com/chemeris/msinttypes/master/stdint.h -o ..\stdint.h
       }

--- a/src/win32/modbus.vcproj
+++ b/src/win32/modbus.vcproj
@@ -21,8 +21,8 @@
 	<Configurations>
 		<Configuration
 			Name="Debug|Win32"
-			OutputDirectory="$(SolutionDir)"
-			IntermediateDirectory="$(ConfigurationName)"
+			OutputDirectory="$(SolutionDir)$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
 			ConfigurationType="2"
 			CharacterSet="2"
 			EnableManagedIncrementalBuild="0"
@@ -114,8 +114,8 @@
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
-			OutputDirectory="$(SolutionDir)"
-			IntermediateDirectory="$(ConfigurationName)"
+			OutputDirectory="$(SolutionDir)$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
 			ConfigurationType="2"
 			CharacterSet="2"
 			WholeProgramOptimization="1"
@@ -189,7 +189,6 @@
 			/>
 			<Tool
 				Name="VCManifestTool"
-				SuppressStartupBanner="false"
 			/>
 			<Tool
 				Name="VCXDCMakeTool"
@@ -211,7 +210,7 @@
 			Name="Debug|x64"
 			OutputDirectory="$(SolutionDir)$(PlatformName)\$(ConfigurationName)"
 			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
-			ConfigurationType="1"
+			ConfigurationType="2"
 			CharacterSet="2"
 			>
 			<Tool
@@ -233,39 +232,47 @@
 			/>
 			<Tool
 				Name="VCMIDLTool"
-				TargetEnvironment="3"
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
+				EnableIntrinsicFunctions="true"
 				WholeProgramOptimization="false"
-				AdditionalIncludeDirectories="$(SolutionDir)"
-				PreprocessorDefinitions=""
+				AdditionalIncludeDirectories="..\src;..;.;D:/include/msvc_std"
+				PreprocessorDefinitions="W32DEBUG;HAVE_CONFIG_H;DLLBUILD;_CRT_SECURE_NO_DEPRECATE=1;_CRT_NONSTDC_NO_DEPRECATE=1"
 				MinimalRebuild="false"
-				BasicRuntimeChecks="3"
-				RuntimeLibrary="0"
+				ExceptionHandling="0"
+				BasicRuntimeChecks="2"
+				RuntimeLibrary="1"
+				FloatingPointModel="2"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="3"
 				CompileAs="1"
-				DisableSpecificWarnings="4244;4267"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
 			/>
 			<Tool
 				Name="VCResourceCompilerTool"
+				PreprocessorDefinitions="_MSC_VER"
+				ResourceOutputFileName="$(SolutionDir)/modbus.res"
 			/>
 			<Tool
 				Name="VCPreLinkEventTool"
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				LinkIncremental="2"
+				AdditionalDependencies="ws2_32.lib"
+				Version="1.0.0"
+				LinkIncremental="1"
+				AdditionalLibraryDirectories=""
+				GenerateManifest="true"
 				GenerateDebugInformation="true"
+				GenerateMapFile="true"
 				SubSystem="1"
-				StackReserveSize="1048576"
-				StackCommitSize="524288"
+				RandomizedBaseAddress="0"
+				DataExecutionPrevention="0"
 				TargetMachine="17"
 			/>
 			<Tool
@@ -273,6 +280,7 @@
 			/>
 			<Tool
 				Name="VCManifestTool"
+				SuppressStartupBanner="true"
 			/>
 			<Tool
 				Name="VCXDCMakeTool"
@@ -294,7 +302,7 @@
 			Name="Release|x64"
 			OutputDirectory="$(SolutionDir)$(PlatformName)\$(ConfigurationName)"
 			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
-			ConfigurationType="1"
+			ConfigurationType="2"
 			CharacterSet="2"
 			WholeProgramOptimization="1"
 			>
@@ -345,6 +353,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="ws2_32.lib"
 				LinkIncremental="1"
 				GenerateDebugInformation="true"
 				SubSystem="1"

--- a/src/win32/modbus.vcproj
+++ b/src/win32/modbus.vcproj
@@ -146,7 +146,7 @@
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
 				WholeProgramOptimization="false"
-				AdditionalIncludeDirectories="..\src;..;.;D:/include/msvc_std"
+				AdditionalIncludeDirectories="..\src;..;."
 				PreprocessorDefinitions="HAVE_CONFIG_H;DLLBUILD;_CRT_SECURE_NO_DEPRECATE=1;_CRT_NONSTDC_NO_DEPRECATE=1"
 				ExceptionHandling="0"
 				RuntimeLibrary="0"


### PR DESCRIPTION
I hoped to find 'official' Windows binaries somewhere, but unfortunately they don't seem to exist?
As building binaries with MSVC under Windows is often quite… unpleasant, and I need reproducible builds of libmodbus, I've checked free cloud CI service AppVeyor (think: Travis for Windows).
And some ~50 builds and an afternoon later I came up with the attached `appveyor.yml`.

I've found `modbus.vcproj` in a broken state, the settings for the 64 bit build were wrong (Application output type instead DLL), and `ws2_32.lib` dependencies were missing. I've fixed it as well. (I did not try it with a GUI version of MSVC, but it works for the AppVeyor builds, so I guess it's syntactically fine).

If these additions are good to be added, you could couple the libmodbus repository with AppVeyor, and benefit from automatic builds. As a nice upside, AppVeyor seems to host the produced artifacts for each build then: (With a little more work they could be pushed somewhere else as well).

See e.g. AppVeyor CI'ing my libmodbus fork: 
https://ci.appveyor.com/project/csachs/libmodbus
And the Artifacts (ZIP Archives containing the `.dll`, `.lib`, `modbus.h` etc.)
https://ci.appveyor.com/project/csachs/libmodbus/build/job/1774gfinhq88vlv5/artifacts (32 bit)
https://ci.appveyor.com/project/csachs/libmodbus/build/job/jnhrgumj1gojrnxs/artifacts (64 bit)

Best regards, Christian