### PR TITLE
CodingStyle: add .clang-format and the derived changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+---
+BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AllowShortFunctionsOnASingleLine: Inline
+BreakBeforeBraces: Custom
+BraceWrapping: {
+    AfterClass: 'false'
+    AfterEnum: 'false'
+    AfterFunction: 'true'
+    AfterNamespace: 'false'
+    AfterStruct: 'false'
+    AfterUnion: 'false'
+    BeforeCatch: 'false'
+    BeforeElse: 'false'
+}
+ColumnLimit:     0
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+IndentWidth:     4
+ObjCBlockIndentWidth: 4
+SpaceAfterCStyleCast: true
+TabWidth:        4
+UseTab:          Never
+SortIncludes:    'false'
+SpaceAfterCStyleCast: 'false'
+...

--- a/src/modbus-data.c
+++ b/src/modbus-data.c
@@ -76,8 +76,8 @@ void modbus_set_bits_from_byte(uint8_t *dest, int idx, const uint8_t value)
 {
     int i;
 
-    for (i=0; i < 8; i++) {
-        dest[idx+i] = (value & (1 << i)) ? 1 : 0;
+    for (i = 0; i < 8; i++) {
+        dest[idx + i] = (value & (1 << i)) ? 1 : 0;
     }
 }
 
@@ -111,8 +111,8 @@ uint8_t modbus_get_byte_from_bits(const uint8_t *src, int idx,
         nb_bits = 8;
     }
 
-    for (i=0; i < nb_bits; i++) {
-        value |= (src[idx+i] << i);
+    for (i = 0; i < nb_bits; i++) {
+        value |= (src[idx + i] << i);
     }
 
     return value;

--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -40,7 +40,7 @@ MODBUS_BEGIN_DECLS
 #define _BYTE_TIMEOUT        500000
 
 typedef enum {
-    _MODBUS_BACKEND_TYPE_RTU=0,
+    _MODBUS_BACKEND_TYPE_RTU = 0,
     _MODBUS_BACKEND_TYPE_TCP
 } modbus_backend_type_t;
 
@@ -69,24 +69,24 @@ typedef struct _modbus_backend {
     unsigned int header_length;
     unsigned int checksum_length;
     unsigned int max_adu_length;
-    int (*set_slave) (modbus_t *ctx, int slave);
-    int (*build_request_basis) (modbus_t *ctx, int function, int addr,
-                                int nb, uint8_t *req);
-    int (*build_response_basis) (sft_t *sft, uint8_t *rsp);
-    int (*prepare_response_tid) (const uint8_t *req, int *req_length);
-    int (*send_msg_pre) (uint8_t *req, int req_length);
-    ssize_t (*send) (modbus_t *ctx, const uint8_t *req, int req_length);
-    int (*receive) (modbus_t *ctx, uint8_t *req);
-    ssize_t (*recv) (modbus_t *ctx, uint8_t *rsp, int rsp_length);
-    int (*check_integrity) (modbus_t *ctx, uint8_t *msg,
-                            const int msg_length);
-    int (*pre_check_confirmation) (modbus_t *ctx, const uint8_t *req,
-                                   const uint8_t *rsp, int rsp_length);
-    int (*connect) (modbus_t *ctx);
-    void (*close) (modbus_t *ctx);
-    int (*flush) (modbus_t *ctx);
-    int (*select) (modbus_t *ctx, fd_set *rset, struct timeval *tv, int msg_length);
-    void (*free) (modbus_t *ctx);
+    int (*set_slave)(modbus_t *ctx, int slave);
+    int (*build_request_basis)(modbus_t *ctx, int function, int addr,
+                               int nb, uint8_t *req);
+    int (*build_response_basis)(sft_t *sft, uint8_t *rsp);
+    int (*prepare_response_tid)(const uint8_t *req, int *req_length);
+    int (*send_msg_pre)(uint8_t *req, int req_length);
+    ssize_t (*send)(modbus_t *ctx, const uint8_t *req, int req_length);
+    int (*receive)(modbus_t *ctx, uint8_t *req);
+    ssize_t (*recv)(modbus_t *ctx, uint8_t *rsp, int rsp_length);
+    int (*check_integrity)(modbus_t *ctx, uint8_t *msg,
+                           const int msg_length);
+    int (*pre_check_confirmation)(modbus_t *ctx, const uint8_t *req,
+                                  const uint8_t *rsp, int rsp_length);
+    int (*connect)(modbus_t *ctx);
+    void (*close)(modbus_t *ctx);
+    int (*flush)(modbus_t *ctx);
+    int (*select)(modbus_t *ctx, fd_set *rset, struct timeval *tv, int msg_length);
+    void (*free)(modbus_t *ctx);
 } modbus_backend_t;
 
 struct _modbus {
@@ -113,4 +113,4 @@ size_t strlcpy(char *dest, const char *src, size_t dest_size);
 
 MODBUS_END_DECLS
 
-#endif  /* MODBUS_PRIVATE_H */
+#endif /* MODBUS_PRIVATE_H */

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -67,7 +67,7 @@ typedef struct _modbus_rtu {
     int rts;
     int rts_delay;
     int onebyte_time;
-    void (*set_rts) (modbus_t *ctx, int on);
+    void (*set_rts)(modbus_t *ctx, int on);
 #endif
     /* To handle many slaves on the same link */
     int confirmation_to_ignore;

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -674,7 +674,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
         break;
 #endif
 #ifdef B1152000
-   case 1152000:
+    case 1152000:
         speed = B1152000;
         break;
 #endif
@@ -749,7 +749,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
 
     /* Stop bit (1 or 2) */
     if (ctx_rtu->stop_bit == 1)
-        tios.c_cflag &=~ CSTOPB;
+        tios.c_cflag &= ~CSTOPB;
     else /* 2 */
         tios.c_cflag |= CSTOPB;
 
@@ -757,11 +757,11 @@ static int _modbus_rtu_connect(modbus_t *ctx)
        PARODD       Use odd parity instead of even */
     if (ctx_rtu->parity == 'N') {
         /* None */
-        tios.c_cflag &=~ PARENB;
+        tios.c_cflag &= ~PARENB;
     } else if (ctx_rtu->parity == 'E') {
         /* Even */
         tios.c_cflag |= PARENB;
-        tios.c_cflag &=~ PARODD;
+        tios.c_cflag &= ~PARODD;
     } else {
         /* Odd */
         tios.c_cflag |= PARENB;
@@ -843,7 +843,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     */
 
     /* Raw ouput */
-    tios.c_oflag &=~ OPOST;
+    tios.c_oflag &= ~OPOST;
 
     /* C_CC         Control characters
        VMIN         Minimum number of characters to read
@@ -1028,7 +1028,7 @@ int modbus_rtu_set_rts(modbus_t *ctx, int mode)
     return -1;
 }
 
-int modbus_rtu_set_custom_rts(modbus_t *ctx, void (*set_rts) (modbus_t *ctx, int on))
+int modbus_rtu_set_custom_rts(modbus_t *ctx, void (*set_rts)(modbus_t *ctx, int on))
 {
     if (ctx == NULL) {
         errno = EINVAL;
@@ -1156,7 +1156,7 @@ static int _modbus_rtu_select(modbus_t *ctx, fd_set *rset,
         return -1;
     }
 #else
-    while ((s_rc = select(ctx->s+1, rset, NULL, NULL, tv)) == -1) {
+    while ((s_rc = select(ctx->s + 1, rset, NULL, NULL, tv)) == -1) {
         if (errno == EINTR) {
             if (ctx->debug) {
                 fprintf(stderr, "A non blocked signal was caught\n");
@@ -1179,7 +1179,8 @@ static int _modbus_rtu_select(modbus_t *ctx, fd_set *rset,
     return s_rc;
 }
 
-static void _modbus_rtu_free(modbus_t *ctx) {
+static void _modbus_rtu_free(modbus_t *ctx)
+{
     if (ctx->backend_data) {
         free(((modbus_rtu_t *)ctx->backend_data)->device);
         free(ctx->backend_data);
@@ -1207,10 +1208,9 @@ const modbus_backend_t _modbus_rtu_backend = {
     _modbus_rtu_close,
     _modbus_rtu_flush,
     _modbus_rtu_select,
-    _modbus_rtu_free
-};
+    _modbus_rtu_free};
 
-modbus_t* modbus_new_rtu(const char *device,
+modbus_t *modbus_new_rtu(const char *device,
                          int baud, char parity, int data_bit,
                          int stop_bit)
 {

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -16,7 +16,7 @@ MODBUS_BEGIN_DECLS
  */
 #define MODBUS_RTU_MAX_ADU_LENGTH  256
 
-MODBUS_API modbus_t* modbus_new_rtu(const char *device, int baud, char parity,
+MODBUS_API modbus_t *modbus_new_rtu(const char *device, int baud, char parity,
                                     int data_bit, int stop_bit);
 
 #define MODBUS_RTU_RS232 0
@@ -32,7 +32,7 @@ MODBUS_API int modbus_rtu_get_serial_mode(modbus_t *ctx);
 MODBUS_API int modbus_rtu_set_rts(modbus_t *ctx, int mode);
 MODBUS_API int modbus_rtu_get_rts(modbus_t *ctx);
 
-MODBUS_API int modbus_rtu_set_custom_rts(modbus_t *ctx, void (*set_rts) (modbus_t *ctx, int on));
+MODBUS_API int modbus_rtu_set_custom_rts(modbus_t *ctx, void (*set_rts)(modbus_t *ctx, int on));
 
 MODBUS_API int modbus_rtu_set_rts_delay(modbus_t *ctx, int us);
 MODBUS_API int modbus_rtu_get_rts_delay(modbus_t *ctx);

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -146,7 +146,6 @@ static int _modbus_tcp_build_response_basis(sft_t *sft, uint8_t *rsp)
     return _MODBUS_TCP_PRESET_RSP_LENGTH;
 }
 
-
 static int _modbus_tcp_prepare_response_tid(const uint8_t *req, int *req_length)
 {
     return (req[0] << 8) + req[1];
@@ -172,11 +171,13 @@ static ssize_t _modbus_tcp_send(modbus_t *ctx, const uint8_t *req, int req_lengt
     return send(ctx->s, (const char *)req, req_length, MSG_NOSIGNAL);
 }
 
-static int _modbus_tcp_receive(modbus_t *ctx, uint8_t *req) {
+static int _modbus_tcp_receive(modbus_t *ctx, uint8_t *req)
+{
     return _modbus_receive_msg(ctx, req, MSG_INDICATION);
 }
 
-static ssize_t _modbus_tcp_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length) {
+static ssize_t _modbus_tcp_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length)
+{
     return recv(ctx->s, (char *)rsp, rsp_length, 0);
 }
 
@@ -458,7 +459,7 @@ static int _modbus_tcp_flush(modbus_t *ctx)
         tv.tv_usec = 0;
         FD_ZERO(&rset);
         FD_SET(ctx->s, &rset);
-        rc = select(ctx->s+1, &rset, NULL, NULL, &tv);
+        rc = select(ctx->s + 1, &rset, NULL, NULL, &tv);
         if (rc == -1) {
             return -1;
         }
@@ -569,7 +570,7 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
         service = ctx_tcp_pi->service;
     }
 
-    memset(&ai_hints, 0, sizeof (ai_hints));
+    memset(&ai_hints, 0, sizeof(ai_hints));
     /* If node is not NULL, than the AI_PASSIVE flag is ignored. */
     ai_hints.ai_flags |= AI_PASSIVE;
 #ifdef AI_ADDRCONFIG
@@ -605,7 +606,7 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
         } else {
             int enable = 1;
             rc = setsockopt(s, SOL_SOCKET, SO_REUSEADDR,
-                            (void *)&enable, sizeof (enable));
+                            (void *)&enable, sizeof(enable));
             if (rc != 0) {
                 close(s);
                 if (ctx->debug) {
@@ -707,7 +708,7 @@ int modbus_tcp_pi_accept(modbus_t *ctx, int *s)
 static int _modbus_tcp_select(modbus_t *ctx, fd_set *rset, struct timeval *tv, int length_to_read)
 {
     int s_rc;
-    while ((s_rc = select(ctx->s+1, rset, NULL, NULL, tv)) == -1) {
+    while ((s_rc = select(ctx->s + 1, rset, NULL, NULL, tv)) == -1) {
         if (errno == EINTR) {
             if (ctx->debug) {
                 fprintf(stderr, "A non blocked signal was caught\n");
@@ -728,7 +729,8 @@ static int _modbus_tcp_select(modbus_t *ctx, fd_set *rset, struct timeval *tv, i
     return s_rc;
 }
 
-static void _modbus_tcp_free(modbus_t *ctx) {
+static void _modbus_tcp_free(modbus_t *ctx)
+{
     free(ctx->backend_data);
     free(ctx);
 }
@@ -778,7 +780,7 @@ const modbus_backend_t _modbus_tcp_pi_backend = {
     _modbus_tcp_free
 };
 
-modbus_t* modbus_new_tcp(const char *ip, int port)
+modbus_t *modbus_new_tcp(const char *ip, int port)
 {
     modbus_t *ctx;
     modbus_tcp_t *ctx_tcp;
@@ -842,8 +844,7 @@ modbus_t* modbus_new_tcp(const char *ip, int port)
     return ctx;
 }
 
-
-modbus_t* modbus_new_tcp_pi(const char *node, const char *service)
+modbus_t *modbus_new_tcp_pi(const char *node, const char *service)
 {
     modbus_t *ctx;
     modbus_tcp_pi_t *ctx_tcp_pi;

--- a/src/modbus-tcp.h
+++ b/src/modbus-tcp.h
@@ -39,11 +39,11 @@ MODBUS_BEGIN_DECLS
  */
 #define MODBUS_TCP_MAX_ADU_LENGTH  260
 
-MODBUS_API modbus_t* modbus_new_tcp(const char *ip_address, int port);
+MODBUS_API modbus_t *modbus_new_tcp(const char *ip_address, int port);
 MODBUS_API int modbus_tcp_listen(modbus_t *ctx, int nb_connection);
 MODBUS_API int modbus_tcp_accept(modbus_t *ctx, int *s);
 
-MODBUS_API modbus_t* modbus_new_tcp_pi(const char *node, const char *service);
+MODBUS_API modbus_t *modbus_new_tcp_pi(const char *node, const char *service);
 MODBUS_API int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection);
 MODBUS_API int modbus_tcp_pi_accept(modbus_t *ctx, int *s);
 

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -41,7 +41,8 @@ typedef enum {
     _STEP_DATA
 } _step_t;
 
-const char *modbus_strerror(int errnum) {
+const char *modbus_strerror(int errnum)
+{
     switch (errnum) {
     case EMBXILFUN:
         return "Illegal function";
@@ -137,8 +138,7 @@ static unsigned int compute_response_length_from_request(modbus_t *ctx, uint8_t 
         /* Header + nb values (code from write_bits) */
         int nb = (req[offset + 3] << 8) | req[offset + 4];
         length = 2 + (nb / 8) + ((nb % 8) ? 1 : 0);
-    }
-        break;
+    } break;
     case MODBUS_FC_WRITE_AND_READ_REGISTERS:
     case MODBUS_FC_READ_HOLDING_REGISTERS:
     case MODBUS_FC_READ_INPUT_REGISTERS:
@@ -323,7 +323,6 @@ static int compute_data_length_after_meta(modbus_t *ctx, uint8_t *msg,
     return length;
 }
 
-
 /* Waits a response from a modbus server or a request from a modbus client.
    This function blocks if there is no replies (3 timeouts).
 
@@ -425,7 +424,7 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
         /* Display the hex code of each character received */
         if (ctx->debug) {
             int i;
-            for (i=0; i < rc; i++)
+            for (i = 0; i < rc; i++)
                 printf("<%.2X>", msg[msg_length + i]);
         }
 
@@ -669,7 +668,7 @@ static int response_io_status(uint8_t *tab_io_status,
 static int response_exception(modbus_t *ctx, sft_t *sft,
                               int exception_code, uint8_t *rsp,
                               unsigned int to_flush,
-                              const char* template, ...)
+                              const char *template, ...)
 {
     int rsp_length;
 
@@ -735,7 +734,7 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
         int start_bits = is_input ? mb_mapping->start_input_bits : mb_mapping->start_bits;
         int nb_bits = is_input ? mb_mapping->nb_input_bits : mb_mapping->nb_bits;
         uint8_t *tab_bits = is_input ? mb_mapping->tab_input_bits : mb_mapping->tab_bits;
-        const char * const name = is_input ? "read_input_bits" : "read_bits";
+        const char *const name = is_input ? "read_input_bits" : "read_bits";
         int nb = (req[offset + 3] << 8) + req[offset + 4];
         /* The mapping can be shifted to reduce memory consumption and it
            doesn't always start at address zero. */
@@ -766,7 +765,7 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
         int start_registers = is_input ? mb_mapping->start_input_registers : mb_mapping->start_registers;
         int nb_registers = is_input ? mb_mapping->nb_input_registers : mb_mapping->nb_registers;
         uint16_t *tab_registers = is_input ? mb_mapping->tab_input_registers : mb_mapping->tab_registers;
-        const char * const name = is_input ? "read_input_registers" : "read_registers";
+        const char *const name = is_input ? "read_input_registers" : "read_registers";
         int nb = (req[offset + 3] << 8) + req[offset + 4];
         /* The mapping can be shifted to reduce memory consumption and it
            doesn't always start at address zero. */
@@ -935,7 +934,7 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
             uint16_t and = (req[offset + 3] << 8) + req[offset + 4];
             uint16_t or = (req[offset + 5] << 8) + req[offset + 6];
 
-            data = (data & and) | (or & (~and));
+            data = (data & and) | (or &(~and));
             mb_mapping->tab_registers[mapping_address] = data;
             memcpy(rsp, req, req_length);
             rsp_length = req_length;
@@ -997,7 +996,9 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
 
     /* Suppress any responses when the request was a broadcast */
     return (ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU &&
-            slave == MODBUS_BROADCAST_ADDRESS) ? 0 : send_msg(ctx, rsp, rsp_length);
+            slave == MODBUS_BROADCAST_ADDRESS)
+               ? 0
+               : send_msg(ctx, rsp, rsp_length);
 }
 
 int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,
@@ -1072,7 +1073,6 @@ static int read_io_status(modbus_t *ctx, int function,
                 dest[pos++] = (temp & bit) ? TRUE : FALSE;
                 bit = bit << 1;
             }
-
         }
     }
 
@@ -1107,7 +1107,6 @@ int modbus_read_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest)
     else
         return nb;
 }
-
 
 /* Same as modbus_read_bits but reads the remote device input table */
 int modbus_read_input_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest)
@@ -1176,7 +1175,7 @@ static int read_registers(modbus_t *ctx, int function, int addr, int nb,
         for (i = 0; i < rc; i++) {
             /* shift reg hi_byte to temp OR with lo_byte */
             dest[i] = (rsp[offset + 2 + (i << 1)] << 8) |
-                rsp[offset + 3 + (i << 1)];
+                      rsp[offset + 3 + (i << 1)];
         }
     }
 
@@ -1328,7 +1327,7 @@ int modbus_write_bits(modbus_t *ctx, int addr, int nb, const uint8_t *src)
             if (src[pos++])
                 req[req_length] |= bit;
             else
-                req[req_length] &=~ bit;
+                req[req_length] &= ~bit;
 
             bit = bit << 1;
         }
@@ -1345,7 +1344,6 @@ int modbus_write_bits(modbus_t *ctx, int addr, int nb, const uint8_t *src)
 
         rc = check_confirmation(ctx, req, rsp, rc);
     }
-
 
     return rc;
 }
@@ -1507,7 +1505,7 @@ int modbus_write_and_read_registers(modbus_t *ctx,
         for (i = 0; i < rc; i++) {
             /* shift reg hi_byte to temp OR with lo_byte */
             dest[i] = (rsp[offset + 2 + (i << 1)] << 8) |
-                rsp[offset + 3 + (i << 1)];
+                      rsp[offset + 3 + (i << 1)];
         }
     }
 
@@ -1551,7 +1549,7 @@ int modbus_report_slave_id(modbus_t *ctx, int max_dest, uint8_t *dest)
 
         /* Byte count, slave id, run indicator status and
            additional data. Truncate copy to max_dest. */
-        for (i=0; i < rc && i < max_dest; i++) {
+        for (i = 0; i < rc && i < max_dest; i++) {
             dest[i] = rsp[offset + i];
         }
     }
@@ -1608,7 +1606,7 @@ int modbus_set_error_recovery(modbus_t *ctx,
     }
 
     /* The type of modbus_error_recovery_mode is unsigned enum */
-    ctx->error_recovery = (uint8_t) error_recovery;
+    ctx->error_recovery = (uint8_t)error_recovery;
     return 0;
 }
 
@@ -1764,7 +1762,7 @@ int modbus_set_debug(modbus_t *ctx, int flag)
    The modbus_mapping_new_ranges() function shall return the new allocated
    structure if successful. Otherwise it shall return NULL and set errno to
    ENOMEM. */
-modbus_mapping_t* modbus_mapping_new_start_address(
+modbus_mapping_t *modbus_mapping_new_start_address(
     unsigned int start_bits, unsigned int nb_bits,
     unsigned int start_input_bits, unsigned int nb_input_bits,
     unsigned int start_registers, unsigned int nb_registers,
@@ -1785,7 +1783,7 @@ modbus_mapping_t* modbus_mapping_new_start_address(
     } else {
         /* Negative number raises a POSIX error */
         mb_mapping->tab_bits =
-            (uint8_t *) malloc(nb_bits * sizeof(uint8_t));
+            (uint8_t *)malloc(nb_bits * sizeof(uint8_t));
         if (mb_mapping->tab_bits == NULL) {
             free(mb_mapping);
             return NULL;
@@ -1800,7 +1798,7 @@ modbus_mapping_t* modbus_mapping_new_start_address(
         mb_mapping->tab_input_bits = NULL;
     } else {
         mb_mapping->tab_input_bits =
-            (uint8_t *) malloc(nb_input_bits * sizeof(uint8_t));
+            (uint8_t *)malloc(nb_input_bits * sizeof(uint8_t));
         if (mb_mapping->tab_input_bits == NULL) {
             free(mb_mapping->tab_bits);
             free(mb_mapping);
@@ -1816,7 +1814,7 @@ modbus_mapping_t* modbus_mapping_new_start_address(
         mb_mapping->tab_registers = NULL;
     } else {
         mb_mapping->tab_registers =
-            (uint16_t *) malloc(nb_registers * sizeof(uint16_t));
+            (uint16_t *)malloc(nb_registers * sizeof(uint16_t));
         if (mb_mapping->tab_registers == NULL) {
             free(mb_mapping->tab_input_bits);
             free(mb_mapping->tab_bits);
@@ -1833,7 +1831,7 @@ modbus_mapping_t* modbus_mapping_new_start_address(
         mb_mapping->tab_input_registers = NULL;
     } else {
         mb_mapping->tab_input_registers =
-            (uint16_t *) malloc(nb_input_registers * sizeof(uint16_t));
+            (uint16_t *)malloc(nb_input_registers * sizeof(uint16_t));
         if (mb_mapping->tab_input_registers == NULL) {
             free(mb_mapping->tab_registers);
             free(mb_mapping->tab_input_bits);
@@ -1848,7 +1846,7 @@ modbus_mapping_t* modbus_mapping_new_start_address(
     return mb_mapping;
 }
 
-modbus_mapping_t* modbus_mapping_new(int nb_bits, int nb_input_bits,
+modbus_mapping_t *modbus_mapping_new(int nb_bits, int nb_input_bits,
                                      int nb_registers, int nb_input_registers)
 {
     return modbus_mapping_new_start_address(

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -169,15 +169,14 @@ typedef struct {
     uint16_t *tab_registers;
 } modbus_mapping_t;
 
-typedef enum
-{
+typedef enum {
     MODBUS_ERROR_RECOVERY_NONE          = 0,
     MODBUS_ERROR_RECOVERY_LINK          = (1<<1),
     MODBUS_ERROR_RECOVERY_PROTOCOL      = (1<<2)
 } modbus_error_recovery_mode;
 
-MODBUS_API int modbus_set_slave(modbus_t* ctx, int slave);
-MODBUS_API int modbus_get_slave(modbus_t* ctx);
+MODBUS_API int modbus_set_slave(modbus_t *ctx, int slave);
+MODBUS_API int modbus_get_slave(modbus_t *ctx);
 MODBUS_API int modbus_set_error_recovery(modbus_t *ctx, modbus_error_recovery_mode error_recovery);
 MODBUS_API int modbus_set_socket(modbus_t *ctx, int s);
 MODBUS_API int modbus_get_socket(modbus_t *ctx);
@@ -217,13 +216,13 @@ MODBUS_API int modbus_write_and_read_registers(modbus_t *ctx, int write_addr, in
                                                uint16_t *dest);
 MODBUS_API int modbus_report_slave_id(modbus_t *ctx, int max_dest, uint8_t *dest);
 
-MODBUS_API modbus_mapping_t* modbus_mapping_new_start_address(
+MODBUS_API modbus_mapping_t *modbus_mapping_new_start_address(
     unsigned int start_bits, unsigned int nb_bits,
     unsigned int start_input_bits, unsigned int nb_input_bits,
     unsigned int start_registers, unsigned int nb_registers,
     unsigned int start_input_registers, unsigned int nb_input_registers);
 
-MODBUS_API modbus_mapping_t* modbus_mapping_new(int nb_bits, int nb_input_bits,
+MODBUS_API modbus_mapping_t *modbus_mapping_new(int nb_bits, int nb_input_bits,
                                                 int nb_registers, int nb_input_registers);
 MODBUS_API void modbus_mapping_free(modbus_mapping_t *mb_mapping);
 
@@ -271,7 +270,7 @@ MODBUS_API int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,
 
 MODBUS_API void modbus_set_bits_from_byte(uint8_t *dest, int idx, const uint8_t value);
 MODBUS_API void modbus_set_bits_from_bytes(uint8_t *dest, int idx, unsigned int nb_bits,
-                                       const uint8_t *tab_byte);
+                                           const uint8_t *tab_byte);
 MODBUS_API uint8_t modbus_get_byte_from_bits(const uint8_t *src, int idx, unsigned int nb_bits);
 MODBUS_API float modbus_get_float(const uint16_t *src);
 MODBUS_API float modbus_get_float_abcd(const uint16_t *src);
@@ -290,4 +289,4 @@ MODBUS_API void modbus_set_float_cdab(float f, uint16_t *dest);
 
 MODBUS_END_DECLS
 
-#endif  /* MODBUS_H */
+#endif /* MODBUS_H */

--- a/tests/bandwidth-client.c
+++ b/tests/bandwidth-client.c
@@ -23,7 +23,7 @@ static uint32_t gettime_ms(void)
     struct timeval tv;
 #if !defined(_MSC_VER)
     gettimeofday(&tv, NULL);
-    return (uint32_t) tv.tv_sec * 1000 + tv.tv_usec / 1000;
+    return (uint32_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
 #else
     return GetTickCount();
 #endif
@@ -82,18 +82,18 @@ int main(int argc, char *argv[])
     }
 
     /* Allocate and initialize the memory to store the status */
-    tab_bit = (uint8_t *) malloc(MODBUS_MAX_READ_BITS * sizeof(uint8_t));
+    tab_bit = (uint8_t *)malloc(MODBUS_MAX_READ_BITS * sizeof(uint8_t));
     memset(tab_bit, 0, MODBUS_MAX_READ_BITS * sizeof(uint8_t));
 
     /* Allocate and initialize the memory to store the registers */
-    tab_reg = (uint16_t *) malloc(MODBUS_MAX_READ_REGISTERS * sizeof(uint16_t));
+    tab_reg = (uint16_t *)malloc(MODBUS_MAX_READ_REGISTERS * sizeof(uint16_t));
     memset(tab_reg, 0, MODBUS_MAX_READ_REGISTERS * sizeof(uint16_t));
 
     printf("READ BITS\n\n");
 
     nb_points = MODBUS_MAX_READ_BITS;
     start = gettime_ms();
-    for (i=0; i<n_loop; i++) {
+    for (i = 0; i < n_loop; i++) {
         rc = modbus_read_bits(ctx, 0, nb_points, tab_bit);
         if (rc == -1) {
             fprintf(stderr, "%s\n", modbus_strerror(errno));
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
 
     nb_points = MODBUS_MAX_READ_REGISTERS;
     start = gettime_ms();
-    for (i=0; i<n_loop; i++) {
+    for (i = 0; i < n_loop; i++) {
         rc = modbus_read_registers(ctx, 0, nb_points, tab_reg);
         if (rc == -1) {
             fprintf(stderr, "%s\n", modbus_strerror(errno));
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
 
     nb_points = MODBUS_MAX_WR_WRITE_REGISTERS;
     start = gettime_ms();
-    for (i=0; i<n_loop; i++) {
+    for (i = 0; i < n_loop; i++) {
         rc = modbus_write_and_read_registers(ctx,
                                              0, nb_points, tab_reg,
                                              0, nb_points, tab_reg);

--- a/tests/bandwidth-server-many-up.c
+++ b/tests/bandwidth-server-many-up.c
@@ -22,7 +22,7 @@
 #include <arpa/inet.h>
 #endif
 
-#define NB_CONNECTION    5
+#define NB_CONNECTION 5
 
 static modbus_t *ctx = NULL;
 static modbus_mapping_t *mb_mapping;
@@ -80,7 +80,7 @@ int main(void)
 
     for (;;) {
         rdset = refset;
-        if (select(fdmax+1, &rdset, NULL, NULL, NULL) == -1) {
+        if (select(fdmax + 1, &rdset, NULL, NULL, NULL) == -1) {
             perror("Server select() failure.");
             close_sigint(1);
         }

--- a/tests/bandwidth-server-one.c
+++ b/tests/bandwidth-server-one.c
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
     int rc;
     int use_backend;
 
-     /* TCP */
+    /* TCP */
     if (argc > 1) {
         if (strcmp(argv[1], "tcp") == 0) {
             use_backend = TCP;
@@ -66,13 +66,13 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    for(;;) {
+    for (;;) {
         uint8_t query[MODBUS_TCP_MAX_ADU_LENGTH];
 
         rc = modbus_receive(ctx, query);
         if (rc > 0) {
             modbus_reply(ctx, query, rc, mb_mapping);
-        } else if (rc  == -1) {
+        } else if (rc == -1) {
             /* Connection closed by the client or error */
             break;
         }

--- a/tests/random-test-client.c
+++ b/tests/random-test-client.c
@@ -50,7 +50,7 @@ int main(void)
     uint16_t *tab_rp_registers;
 
     /* RTU */
-/*
+    /*
     ctx = modbus_new_rtu("/dev/ttyUSB0", 19200, 'N', 8, 1);
     modbus_set_slave(ctx, SERVER_ID);
 */
@@ -69,19 +69,19 @@ int main(void)
     /* Allocate and initialize the different memory spaces */
     nb = ADDRESS_END - ADDRESS_START;
 
-    tab_rq_bits = (uint8_t *) malloc(nb * sizeof(uint8_t));
+    tab_rq_bits = (uint8_t *)malloc(nb * sizeof(uint8_t));
     memset(tab_rq_bits, 0, nb * sizeof(uint8_t));
 
-    tab_rp_bits = (uint8_t *) malloc(nb * sizeof(uint8_t));
+    tab_rp_bits = (uint8_t *)malloc(nb * sizeof(uint8_t));
     memset(tab_rp_bits, 0, nb * sizeof(uint8_t));
 
-    tab_rq_registers = (uint16_t *) malloc(nb * sizeof(uint16_t));
+    tab_rq_registers = (uint16_t *)malloc(nb * sizeof(uint16_t));
     memset(tab_rq_registers, 0, nb * sizeof(uint16_t));
 
-    tab_rp_registers = (uint16_t *) malloc(nb * sizeof(uint16_t));
+    tab_rp_registers = (uint16_t *)malloc(nb * sizeof(uint16_t));
     memset(tab_rp_registers, 0, nb * sizeof(uint16_t));
 
-    tab_rw_rq_registers = (uint16_t *) malloc(nb * sizeof(uint16_t));
+    tab_rw_rq_registers = (uint16_t *)malloc(nb * sizeof(uint16_t));
     memset(tab_rw_rq_registers, 0, nb * sizeof(uint16_t));
 
     nb_loop = nb_fail = 0;
@@ -90,8 +90,8 @@ int main(void)
             int i;
 
             /* Random numbers (short) */
-            for (i=0; i<nb; i++) {
-                tab_rq_registers[i] = (uint16_t) (65535.0*rand() / (RAND_MAX + 1.0));
+            for (i = 0; i < nb; i++) {
+                tab_rq_registers[i] = (uint16_t)(65535.0 * rand() / (RAND_MAX + 1.0));
                 tab_rw_rq_registers[i] = ~tab_rq_registers[i];
                 tab_rq_bits[i] = tab_rq_registers[i] % 2;
             }
@@ -125,7 +125,7 @@ int main(void)
                     printf("Address = %d, nb = %d\n", addr, nb);
                     nb_fail++;
                 } else {
-                    for (i=0; i<nb; i++) {
+                    for (i = 0; i < nb; i++) {
                         if (tab_rp_bits[i] != tab_rq_bits[i]) {
                             printf("ERROR modbus_read_bits\n");
                             printf("Address = %d, value %d (0x%X) != %d (0x%X)\n",
@@ -174,7 +174,7 @@ int main(void)
                     printf("Address = %d, nb = %d\n", addr, nb);
                     nb_fail++;
                 } else {
-                    for (i=0; i<nb; i++) {
+                    for (i = 0; i < nb; i++) {
                         if (tab_rq_registers[i] != tab_rp_registers[i]) {
                             printf("ERROR modbus_read_registers\n");
                             printf("Address = %d, value %d (0x%X) != %d (0x%X)\n",
@@ -194,7 +194,7 @@ int main(void)
                 printf("Address = %d, nb = %d\n", addr, nb);
                 nb_fail++;
             } else {
-                for (i=0; i<nb; i++) {
+                for (i = 0; i < nb; i++) {
                     if (tab_rp_registers[i] != tab_rw_rq_registers[i]) {
                         printf("ERROR modbus_read_and_write_registers READ\n");
                         printf("Address = %d, value %d (0x%X) != %d (0x%X)\n",
@@ -210,7 +210,7 @@ int main(void)
                     printf("Address = %d, nb = %d\n", addr, nb);
                     nb_fail++;
                 } else {
-                    for (i=0; i<nb; i++) {
+                    for (i = 0; i < nb; i++) {
                         if (tab_rw_rq_registers[i] != tab_rp_registers[i]) {
                             printf("ERROR modbus_read_and_write_registers WRITE\n");
                             printf("Address = %d, value %d (0x%X) != %d (0x%X)\n",

--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -28,19 +28,21 @@ int send_crafted_request(modbus_t *ctx, int function,
                          int backend_length, int backend_offset);
 int equal_dword(uint16_t *tab_reg, const uint32_t value);
 
-#define BUG_REPORT(_cond, _format, _args ...) \
-    printf("\nLine %d: assertion error for '%s': " _format "\n", __LINE__, # _cond, ## _args)
+#define BUG_REPORT(_cond, _format, _args...) \
+    printf("\nLine %d: assertion error for '%s': " _format "\n", __LINE__, #_cond, ##_args)
 
-#define ASSERT_TRUE(_cond, _format, __args...) {  \
-    if (_cond) {                                  \
-        printf("OK\n");                           \
-    } else {                                      \
-        BUG_REPORT(_cond, _format, ## __args);    \
-        goto close;                               \
-    }                                             \
-};
+#define ASSERT_TRUE(_cond, _format, __args...)    \
+    {                                             \
+        if (_cond) {                              \
+            printf("OK\n");                       \
+        } else {                                  \
+            BUG_REPORT(_cond, _format, ##__args); \
+            goto close;                           \
+        }                                         \
+    };
 
-int equal_dword(uint16_t *tab_reg, const uint32_t value) {
+int equal_dword(uint16_t *tab_reg, const uint32_t value)
+{
     return ((tab_reg[0] == (value >> 16)) && (tab_reg[1] == (value & 0xFFFF)));
 }
 
@@ -96,7 +98,7 @@ int main(int argc, char *argv[])
     modbus_set_debug(ctx, TRUE);
     modbus_set_error_recovery(ctx,
                               MODBUS_ERROR_RECOVERY_LINK |
-                              MODBUS_ERROR_RECOVERY_PROTOCOL);
+                                  MODBUS_ERROR_RECOVERY_PROTOCOL);
 
     if (use_backend == RTU) {
         modbus_set_slave(ctx, SERVER_ID);
@@ -114,17 +116,17 @@ int main(int argc, char *argv[])
 
     printf("1/1 No response timeout modification on connect: ");
     ASSERT_TRUE(old_response_to_sec == new_response_to_sec &&
-                old_response_to_usec == new_response_to_usec, "");
+                    old_response_to_usec == new_response_to_usec,
+                "");
 
     /* Allocate and initialize the memory to store the bits */
     nb_points = (UT_BITS_NB > UT_INPUT_BITS_NB) ? UT_BITS_NB : UT_INPUT_BITS_NB;
-    tab_rp_bits = (uint8_t *) malloc(nb_points * sizeof(uint8_t));
+    tab_rp_bits = (uint8_t *)malloc(nb_points * sizeof(uint8_t));
     memset(tab_rp_bits, 0, nb_points * sizeof(uint8_t));
 
     /* Allocate and initialize the memory to store the registers */
-    nb_points = (UT_REGISTERS_NB > UT_INPUT_REGISTERS_NB) ?
-        UT_REGISTERS_NB : UT_INPUT_REGISTERS_NB;
-    tab_rp_registers = (uint16_t *) malloc(nb_points * sizeof(uint16_t));
+    nb_points = (UT_REGISTERS_NB > UT_INPUT_REGISTERS_NB) ? UT_REGISTERS_NB : UT_INPUT_REGISTERS_NB;
+    tab_rp_registers = (uint16_t *)malloc(nb_points * sizeof(uint16_t));
     memset(tab_rp_registers, 0, nb_points * sizeof(uint16_t));
 
     printf("\nTEST WRITE/READ:\n");
@@ -163,7 +165,7 @@ int main(int argc, char *argv[])
     while (nb_points > 0) {
         int nb_bits = (nb_points > 8) ? 8 : nb_points;
 
-        value = modbus_get_byte_from_bits(tab_rp_bits, i*8, nb_bits);
+        value = modbus_get_byte_from_bits(tab_rp_bits, i * 8, nb_bits);
         ASSERT_TRUE(value == UT_BITS_TAB[i], "FAILED (%0X != %0X)\n",
                     value, UT_BITS_TAB[i]);
 
@@ -183,7 +185,7 @@ int main(int argc, char *argv[])
     nb_points = UT_INPUT_BITS_NB;
     while (nb_points > 0) {
         int nb_bits = (nb_points > 8) ? 8 : nb_points;
-        value = modbus_get_byte_from_bits(tab_rp_bits, i*8, nb_bits);
+        value = modbus_get_byte_from_bits(tab_rp_bits, i * 8, nb_bits);
         ASSERT_TRUE(value == UT_INPUT_BITS_TAB[i], "FAILED (%0X != %0X)\n",
                     value, UT_INPUT_BITS_TAB[i]);
 
@@ -218,7 +220,7 @@ int main(int argc, char *argv[])
     printf("2/5 modbus_read_registers: ");
     ASSERT_TRUE(rc == UT_REGISTERS_NB, "FAILED (nb points %d)\n", rc);
 
-    for (i=0; i < UT_REGISTERS_NB; i++) {
+    for (i = 0; i < UT_REGISTERS_NB; i++) {
         ASSERT_TRUE(tab_rp_registers[i] == UT_REGISTERS_TAB[i],
                     "FAILED (%0X != %0X)\n",
                     tab_rp_registers[i], UT_REGISTERS_TAB[i]);
@@ -230,8 +232,9 @@ int main(int argc, char *argv[])
     ASSERT_TRUE(rc == -1, "FAILED (nb_points %d)\n", rc);
 
     nb_points = (UT_REGISTERS_NB >
-                 UT_INPUT_REGISTERS_NB) ?
-        UT_REGISTERS_NB : UT_INPUT_REGISTERS_NB;
+                 UT_INPUT_REGISTERS_NB)
+                    ? UT_REGISTERS_NB
+                    : UT_INPUT_REGISTERS_NB;
     memset(tab_rp_registers, 0, nb_points * sizeof(uint16_t));
 
     /* Write registers to zero from tab_rp_registers and store read registers
@@ -252,13 +255,12 @@ int main(int argc, char *argv[])
                 "FAILED (%0X != %0X)\n",
                 tab_rp_registers[0], UT_REGISTERS_TAB[0]);
 
-    for (i=1; i < UT_REGISTERS_NB; i++) {
+    for (i = 1; i < UT_REGISTERS_NB; i++) {
         ASSERT_TRUE(tab_rp_registers[i] == 0, "FAILED (%0X != %0X)\n",
                     tab_rp_registers[i], 0);
     }
 
     /* End of many registers */
-
 
     /** INPUT REGISTERS **/
     rc = modbus_read_input_registers(ctx, UT_INPUT_REGISTERS_ADDRESS,
@@ -267,7 +269,7 @@ int main(int argc, char *argv[])
     printf("1/1 modbus_read_input_registers: ");
     ASSERT_TRUE(rc == UT_INPUT_REGISTERS_NB, "FAILED (nb points %d)\n", rc);
 
-    for (i=0; i < UT_INPUT_REGISTERS_NB; i++) {
+    for (i = 0; i < UT_INPUT_REGISTERS_NB; i++) {
         ASSERT_TRUE(tab_rp_registers[i] == UT_INPUT_REGISTERS_TAB[i],
                     "FAILED (%0X != %0X)\n",
                     tab_rp_registers[i], UT_INPUT_REGISTERS_TAB[i]);
@@ -375,7 +377,7 @@ int main(int argc, char *argv[])
     ASSERT_TRUE(rc == -1 && errno == EMBXILADD, "");
 
     rc = modbus_write_register(ctx, UT_REGISTERS_ADDRESS + UT_REGISTERS_NB_MAX,
-                                tab_rp_registers[0]);
+                               tab_rp_registers[0]);
     printf("* modbus_write_register (max): ");
     ASSERT_TRUE(rc == -1 && errno == EMBXILADD, "");
 
@@ -454,11 +456,11 @@ int main(int argc, char *argv[])
                                UT_REGISTERS_NB, tab_rp_registers);
     if (use_backend == RTU) {
         const int RAW_REQ_LENGTH = 6;
-        uint8_t raw_req[] = { INVALID_SERVER_ID, 0x03, 0x00, 0x01, 0x01, 0x01 };
+        uint8_t raw_req[] = {INVALID_SERVER_ID, 0x03, 0x00, 0x01, 0x01, 0x01};
         /* Too many points */
-        uint8_t raw_invalid_req[] = { INVALID_SERVER_ID, 0x03, 0x00, 0x01, 0xFF, 0xFF };
+        uint8_t raw_invalid_req[] = {INVALID_SERVER_ID, 0x03, 0x00, 0x01, 0xFF, 0xFF};
         const int RAW_RSP_LENGTH = 7;
-        uint8_t raw_rsp[] = { INVALID_SERVER_ID, 0x03, 0x04, 0, 0, 0, 0 };
+        uint8_t raw_rsp[] = {INVALID_SERVER_ID, 0x03, 0x04, 0, 0, 0, 0};
         uint8_t rsp[MODBUS_RTU_MAX_ADU_LENGTH];
 
         /* No response in RTU mode */
@@ -467,7 +469,6 @@ int main(int argc, char *argv[])
 
         /* The slave raises a timeout on a confirmation to ignore because if an
          * indication for another slave is received, a confirmation must follow */
-
 
         /* Send a pair of indication/confirmation to the slave with a different
          * slave ID to simulate a communication on a RS485 bus. At first, the
@@ -524,7 +525,7 @@ int main(int argc, char *argv[])
     rc = modbus_report_slave_id(ctx, NB_REPORT_SLAVE_ID - 1, tab_rp_bits);
     /* Return the size required (response size) but respects the defined limit */
     ASSERT_TRUE(rc == NB_REPORT_SLAVE_ID &&
-                tab_rp_bits[NB_REPORT_SLAVE_ID - 1] == 42,
+                    tab_rp_bits[NB_REPORT_SLAVE_ID - 1] == 42,
                 "Return is rc %d (%d) and marker is %d (42)",
                 rc, NB_REPORT_SLAVE_ID, tab_rp_bits[NB_REPORT_SLAVE_ID - 1]);
 
@@ -542,7 +543,7 @@ int main(int argc, char *argv[])
     /* Print additional data as string */
     if (rc > 2) {
         printf("Additional data: ");
-        for (i=2; i < rc; i++) {
+        for (i = 2; i < rc; i++) {
             printf("%c", tab_rp_bits[i]);
         }
         printf("\n");
@@ -641,7 +642,7 @@ int main(int argc, char *argv[])
     printf("\nTEST BAD RESPONSE ERROR:\n");
 
     /* Allocate only the required space */
-    tab_rp_registers_bad = (uint16_t *) malloc(
+    tab_rp_registers_bad = (uint16_t *)malloc(
         UT_REGISTERS_NB_SPECIAL * sizeof(uint16_t));
 
     rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS,
@@ -707,8 +708,7 @@ int test_server(modbus_t *ctx, int use_backend)
         /* function, address, 5 values */
         MODBUS_FC_READ_HOLDING_REGISTERS,
         UT_REGISTERS_ADDRESS >> 8, UT_REGISTERS_ADDRESS & 0xFF,
-        0x0, 0x05
-    };
+        0x0, 0x05};
     /* Write and read registers request */
     const int RW_RAW_REQ_LEN = 13;
     uint8_t rw_raw_req[] = {
@@ -725,8 +725,7 @@ int test_server(modbus_t *ctx, int use_backend)
         /* Write byte count */
         1 * 2,
         /* One data to write... */
-        0x12, 0x34
-    };
+        0x12, 0x34};
     const int WRITE_RAW_REQ_LEN = 13;
     uint8_t write_raw_req[] = {
         slave,
@@ -737,13 +736,11 @@ int test_server(modbus_t *ctx, int use_backend)
         /* 3 values, 6 bytes */
         0x00, 0x03, 0x06,
         /* Dummy data to write */
-        0x02, 0x2B, 0x00, 0x01, 0x00, 0x64
-    };
+        0x02, 0x2B, 0x00, 0x01, 0x00, 0x64};
     const int INVALID_FC = 0x42;
     const int INVALID_FC_REQ_LEN = 6;
     uint8_t invalid_fc_raw_req[] = {
-        slave, 0x42, 0x00, 0x00, 0x00, 0x00
-    };
+        slave, 0x42, 0x00, 0x00, 0x00, 0x00};
 
     int req_length;
     uint8_t rsp[MODBUS_TCP_MAX_ADU_LENGTH];
@@ -751,14 +748,12 @@ int test_server(modbus_t *ctx, int use_backend)
         MODBUS_FC_READ_COILS,
         MODBUS_FC_READ_DISCRETE_INPUTS,
         MODBUS_FC_READ_HOLDING_REGISTERS,
-        MODBUS_FC_READ_INPUT_REGISTERS
-    };
+        MODBUS_FC_READ_INPUT_REGISTERS};
     int tab_read_nb_max[] = {
         MODBUS_MAX_READ_BITS + 1,
         MODBUS_MAX_READ_BITS + 1,
         MODBUS_MAX_READ_REGISTERS + 1,
-        MODBUS_MAX_READ_REGISTERS + 1
-    };
+        MODBUS_MAX_READ_REGISTERS + 1};
     int backend_length;
     int backend_offset;
 
@@ -793,7 +788,7 @@ int test_server(modbus_t *ctx, int use_backend)
 
     /* Try to read more values than a response could hold for all data
        types. */
-    for (i=0; i<4; i++) {
+    for (i = 0; i < 4; i++) {
         rc = send_crafted_request(ctx, tab_read_function[i],
                                   read_raw_req, READ_RAW_REQ_LEN,
                                   tab_read_nb_max[i], 0,
@@ -831,7 +826,8 @@ int test_server(modbus_t *ctx, int use_backend)
     rc = modbus_receive_confirmation(ctx, rsp);
     printf("Return an exception on unknown function code: ");
     ASSERT_TRUE(rc == (backend_length + EXCEPTION_RC) &&
-                rsp[backend_offset] == (0x80 + INVALID_FC), "")
+                    rsp[backend_offset] == (0x80 + INVALID_FC),
+                "")
 
     modbus_set_response_timeout(ctx, old_response_to_sec, old_response_to_usec);
     return 0;
@@ -839,7 +835,6 @@ close:
     modbus_set_response_timeout(ctx, old_response_to_sec, old_response_to_usec);
     return -1;
 }
-
 
 int send_crafted_request(modbus_t *ctx, int function,
                          uint8_t *req, int req_len,
@@ -849,7 +844,7 @@ int send_crafted_request(modbus_t *ctx, int function,
     uint8_t rsp[MODBUS_TCP_MAX_ADU_LENGTH];
     int j;
 
-    for (j=0; j<2; j++) {
+    for (j = 0; j < 2; j++) {
         int rc;
 
         req[1] = function;
@@ -873,15 +868,16 @@ int send_crafted_request(modbus_t *ctx, int function,
 
         modbus_send_raw_request(ctx, req, req_len * sizeof(uint8_t));
         if (j == 0) {
-            printf("* try function 0x%X: %s 0 values: ", function, bytes ? "write": "read");
+            printf("* try function 0x%X: %s 0 values: ", function, bytes ? "write" : "read");
         } else {
-            printf("* try function 0x%X: %s %d values: ", function, bytes ? "write": "read",
+            printf("* try function 0x%X: %s %d values: ", function, bytes ? "write" : "read",
                    max_value);
         }
         rc = modbus_receive_confirmation(ctx, rsp);
         ASSERT_TRUE(rc == (backend_length + EXCEPTION_RC) &&
-                    rsp[backend_offset] == (0x80 + function) &&
-                    rsp[backend_offset + 1] == MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE, "");
+                        rsp[backend_offset] == (0x80 + function) &&
+                        rsp[backend_offset + 1] == MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE,
+                    "");
     }
     return 0;
 close:

--- a/tests/unit-test-server.c
+++ b/tests/unit-test-server.c
@@ -29,7 +29,7 @@ enum {
     RTU
 };
 
-int main(int argc, char*argv[])
+int main(int argc, char *argv[])
 {
     int s = -1;
     modbus_t *ctx;
@@ -91,8 +91,9 @@ int main(int argc, char*argv[])
                                UT_INPUT_BITS_TAB);
 
     /* Initialize values of INPUT REGISTERS */
-    for (i=0; i < UT_INPUT_REGISTERS_NB; i++) {
-        mb_mapping->tab_input_registers[i] = UT_INPUT_REGISTERS_TAB[i];;
+    for (i = 0; i < UT_INPUT_REGISTERS_NB; i++) {
+        mb_mapping->tab_input_registers[i] = UT_INPUT_REGISTERS_TAB[i];
+        ;
     }
 
     if (use_backend == TCP) {
@@ -127,35 +128,29 @@ int main(int argc, char*argv[])
         if (query[header_length] == 0x03) {
             /* Read holding registers */
 
-            if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 3)
-                == UT_REGISTERS_NB_SPECIAL) {
+            if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 3) == UT_REGISTERS_NB_SPECIAL) {
                 printf("Set an incorrect number of values\n");
                 MODBUS_SET_INT16_TO_INT8(query, header_length + 3,
                                          UT_REGISTERS_NB_SPECIAL - 1);
-            } else if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 1)
-                       == UT_REGISTERS_ADDRESS_SPECIAL) {
+            } else if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 1) == UT_REGISTERS_ADDRESS_SPECIAL) {
                 printf("Reply to this special register address by an exception\n");
                 modbus_reply_exception(ctx, query,
                                        MODBUS_EXCEPTION_SLAVE_OR_SERVER_BUSY);
                 continue;
-            } else if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 1)
-                       == UT_REGISTERS_ADDRESS_INVALID_TID_OR_SLAVE) {
+            } else if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 1) == UT_REGISTERS_ADDRESS_INVALID_TID_OR_SLAVE) {
                 const int RAW_REQ_LENGTH = 5;
                 uint8_t raw_req[] = {
                     (use_backend == RTU) ? INVALID_SERVER_ID : 0xFF,
                     0x03,
-                    0x02, 0x00, 0x00
-                };
+                    0x02, 0x00, 0x00};
 
                 printf("Reply with an invalid TID or slave\n");
                 modbus_send_raw_request(ctx, raw_req, RAW_REQ_LENGTH * sizeof(uint8_t));
                 continue;
-            } else if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 1)
-                       == UT_REGISTERS_ADDRESS_SLEEP_500_MS) {
+            } else if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 1) == UT_REGISTERS_ADDRESS_SLEEP_500_MS) {
                 printf("Sleep 0.5 s before replying\n");
                 usleep(500000);
-            } else if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 1)
-                       == UT_REGISTERS_ADDRESS_BYTE_SLEEP_5_MS) {
+            } else if (MODBUS_GET_INT16_FROM_INT8(query, header_length + 1) == UT_REGISTERS_ADDRESS_BYTE_SLEEP_5_MS) {
                 /* Test low level only available in TCP mode */
                 /* Catch the reply and send reply byte a byte */
                 uint8_t req[] = "\x00\x1C\x00\x00\x00\x05\xFF\x03\x02\x00\x00";
@@ -168,10 +163,10 @@ int main(int argc, char*argv[])
 
                 /* Copy TID */
                 req[1] = query[1];
-                for (i=0; i < req_length; i++) {
+                for (i = 0; i < req_length; i++) {
                     printf("(%.2X)", req[i]);
                     usleep(5000);
-                    rc = send(w_s, (const char*)(req + i), 1, MSG_NOSIGNAL);
+                    rc = send(w_s, (const char *)(req + i), 1, MSG_NOSIGNAL);
                     if (rc == -1) {
                         break;
                     }


### PR DESCRIPTION
This commit adds a .clang-format-file which helps to automate
the code-formatting. This file is as close as it gets to the existing
style. Some things are not supported by clang-format yet
(mainly PreProcessorIndent - currently under code-review).

This commit does not necessarily needs to be merged, but it
helps to show inconsistencies.

I'm using clang-format-5.0 (5.0.0-svn305653-1) on Debian.