### PR TITLE
Added new modbus_receive_nb call to support non-blocking TCP server

### DIFF
--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -77,6 +77,7 @@ typedef struct _modbus_backend {
     int (*send_msg_pre) (uint8_t *req, int req_length);
     ssize_t (*send) (modbus_t *ctx, const uint8_t *req, int req_length);
     int (*receive) (modbus_t *ctx, uint8_t *req);
+    int (*receive_nb) (modbus_t *ctx, uint8_t *req);
     ssize_t (*recv) (modbus_t *ctx, uint8_t *rsp, int rsp_length);
     int (*check_integrity) (modbus_t *ctx, uint8_t *msg,
                             const int msg_length);
@@ -105,7 +106,8 @@ struct _modbus {
 
 void _modbus_init_common(modbus_t *ctx);
 void _error_print(modbus_t *ctx, const char *context);
-int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type);
+int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type,
+                        unsigned int non_blocking);
 
 #ifndef HAVE_STRLCPY
 size_t strlcpy(char *dest, const char *src, size_t dest_size);

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -307,7 +307,7 @@ static int _modbus_rtu_receive(modbus_t *ctx, uint8_t *req)
     modbus_rtu_t *ctx_rtu = ctx->backend_data;
 
     if (ctx_rtu->confirmation_to_ignore) {
-        _modbus_receive_msg(ctx, req, MSG_CONFIRMATION);
+        _modbus_receive_msg(ctx, req, MSG_CONFIRMATION, FALSE);
         /* Ignore errors and reset the flag */
         ctx_rtu->confirmation_to_ignore = FALSE;
         rc = 0;
@@ -315,13 +315,18 @@ static int _modbus_rtu_receive(modbus_t *ctx, uint8_t *req)
             printf("Confirmation to ignore\n");
         }
     } else {
-        rc = _modbus_receive_msg(ctx, req, MSG_INDICATION);
+        rc = _modbus_receive_msg(ctx, req, MSG_INDICATION, FALSE);
         if (rc == 0) {
             /* The next expected message is a confirmation to ignore */
             ctx_rtu->confirmation_to_ignore = TRUE;
         }
     }
     return rc;
+}
+
+static int _modbus_rtu_receive_nb(modbus_t *ctx, uint8_t *req)
+{
+    return -EOPNOTSUPP;
 }
 
 static ssize_t _modbus_rtu_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length)
@@ -1208,6 +1213,7 @@ const modbus_backend_t _modbus_rtu_backend = {
     _modbus_rtu_send_msg_pre,
     _modbus_rtu_send,
     _modbus_rtu_receive,
+    _modbus_rtu_receive_nb,
     _modbus_rtu_recv,
     _modbus_rtu_check_integrity,
     _modbus_rtu_pre_check_confirmation,

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -173,11 +173,15 @@ static ssize_t _modbus_tcp_send(modbus_t *ctx, const uint8_t *req, int req_lengt
 }
 
 static int _modbus_tcp_receive(modbus_t *ctx, uint8_t *req) {
-    return _modbus_receive_msg(ctx, req, MSG_INDICATION);
+    return _modbus_receive_msg(ctx, req, MSG_INDICATION, FALSE);
 }
 
 static ssize_t _modbus_tcp_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length) {
     return recv(ctx->s, (char *)rsp, rsp_length, 0);
+}
+
+static int _modbus_tcp_receive_nb(modbus_t *ctx, uint8_t *req) {
+    return _modbus_receive_msg(ctx, req, MSG_INDICATION, TRUE);
 }
 
 static int _modbus_tcp_check_integrity(modbus_t *ctx, uint8_t *msg, const int msg_length)
@@ -745,6 +749,7 @@ const modbus_backend_t _modbus_tcp_backend = {
     _modbus_tcp_send_msg_pre,
     _modbus_tcp_send,
     _modbus_tcp_receive,
+    _modbus_tcp_receive_nb,
     _modbus_tcp_recv,
     _modbus_tcp_check_integrity,
     _modbus_tcp_pre_check_confirmation,
@@ -768,6 +773,7 @@ const modbus_backend_t _modbus_tcp_pi_backend = {
     _modbus_tcp_send_msg_pre,
     _modbus_tcp_send,
     _modbus_tcp_receive,
+    _modbus_tcp_receive_nb,
     _modbus_tcp_recv,
     _modbus_tcp_check_integrity,
     _modbus_tcp_pre_check_confirmation,

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -337,7 +337,8 @@ static int compute_data_length_after_meta(modbus_t *ctx, uint8_t *msg,
    - read() or recv() error codes
 */
 
-int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
+int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type,
+                        unsigned int non_blocking)
 {
     int rc;
     fd_set rset;
@@ -365,7 +366,7 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
     step = _STEP_FUNCTION;
     length_to_read = ctx->backend->header_length + 1;
 
-    if (msg_type == MSG_INDICATION) {
+    if ((msg_type == MSG_INDICATION) && !non_blocking) {
         /* Wait for a message, we don't know when the message will be
          * received */
         if (ctx->indication_timeout.tv_sec == 0 && ctx->indication_timeout.tv_usec == 0) {
@@ -386,18 +387,20 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
     while (length_to_read != 0) {
         rc = ctx->backend->select(ctx, &rset, p_tv, length_to_read);
         if (rc == -1) {
-            _error_print(ctx, "select");
-            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) {
-                int saved_errno = errno;
+            if ((errno != ETIMEDOUT) || !non_blocking) {
+                _error_print(ctx, "select");
+                if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) {
+                    int saved_errno = errno;
 
-                if (errno == ETIMEDOUT) {
-                    _sleep_response_timeout(ctx);
-                    modbus_flush(ctx);
-                } else if (errno == EBADF) {
-                    modbus_close(ctx);
-                    modbus_connect(ctx);
+                    if (errno == ETIMEDOUT) {
+                        _sleep_response_timeout(ctx);
+                        modbus_flush(ctx);
+                    } else if (errno == EBADF) {
+                        modbus_close(ctx);
+                        modbus_connect(ctx);
+                    }
+                    errno = saved_errno;
                 }
-                errno = saved_errno;
             }
             return -1;
         }
@@ -490,6 +493,17 @@ int modbus_receive(modbus_t *ctx, uint8_t *req)
     return ctx->backend->receive(ctx, req);
 }
 
+/* Receive the request from a modbus master, without blocking */
+int modbus_receive_nb(modbus_t *ctx, uint8_t *req)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return ctx->backend->receive_nb(ctx, req);
+}
+
 /* Receives the confirmation.
 
    The function shall store the read response in rsp and return the number of
@@ -505,7 +519,7 @@ int modbus_receive_confirmation(modbus_t *ctx, uint8_t *rsp)
         return -1;
     }
 
-    return _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+    return _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION, FALSE);
 }
 
 static int check_confirmation(modbus_t *ctx, uint8_t *req,
@@ -1054,7 +1068,7 @@ static int read_io_status(modbus_t *ctx, int function,
         int offset;
         int offset_end;
 
-        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION, FALSE);
         if (rc == -1)
             return -1;
 
@@ -1163,7 +1177,7 @@ static int read_registers(modbus_t *ctx, int function, int addr, int nb,
         int offset;
         int i;
 
-        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION, FALSE);
         if (rc == -1)
             return -1;
 
@@ -1254,7 +1268,7 @@ static int write_single(modbus_t *ctx, int function, int addr, int value)
         /* Used by write_bit and write_register */
         uint8_t rsp[MAX_MESSAGE_LENGTH];
 
-        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION, FALSE);
         if (rc == -1)
             return -1;
 
@@ -1339,7 +1353,7 @@ int modbus_write_bits(modbus_t *ctx, int addr, int nb, const uint8_t *src)
     if (rc > 0) {
         uint8_t rsp[MAX_MESSAGE_LENGTH];
 
-        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION, FALSE);
         if (rc == -1)
             return -1;
 
@@ -1389,7 +1403,7 @@ int modbus_write_registers(modbus_t *ctx, int addr, int nb, const uint16_t *src)
     if (rc > 0) {
         uint8_t rsp[MAX_MESSAGE_LENGTH];
 
-        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION, FALSE);
         if (rc == -1)
             return -1;
 
@@ -1425,7 +1439,7 @@ int modbus_mask_write_register(modbus_t *ctx, int addr, uint16_t and_mask, uint1
         /* Used by write_bit and write_register */
         uint8_t rsp[MAX_MESSAGE_LENGTH];
 
-        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION, FALSE);
         if (rc == -1)
             return -1;
 
@@ -1495,7 +1509,7 @@ int modbus_write_and_read_registers(modbus_t *ctx,
     if (rc > 0) {
         int offset;
 
-        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION, FALSE);
         if (rc == -1)
             return -1;
 
@@ -1539,7 +1553,7 @@ int modbus_report_slave_id(modbus_t *ctx, int max_dest, uint8_t *dest)
         int offset;
         uint8_t rsp[MAX_MESSAGE_LENGTH];
 
-        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION, FALSE);
         if (rc == -1)
             return -1;
 

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -231,6 +231,8 @@ MODBUS_API int modbus_send_raw_request(modbus_t *ctx, uint8_t *raw_req, int raw_
 
 MODBUS_API int modbus_receive(modbus_t *ctx, uint8_t *req);
 
+MODBUS_API int modbus_receive_nb(modbus_t *ctx, uint8_t *req);
+
 MODBUS_API int modbus_receive_confirmation(modbus_t *ctx, uint8_t *rsp);
 
 MODBUS_API int modbus_reply(modbus_t *ctx, const uint8_t *req,


### PR DESCRIPTION
@stephane This PR is my attempt to support a non-blocking `modbus_receive` call so I can run a modbus TCP server in a single threaded loop that does other work besides handling the modbus communications. This is accomplished by adding a simple `modbus_receive_nb` API call that just calls the equivalent backend function (`receive_nb` added to the driver struct). I only implemented the calls for the TCP backends, and just return `-EOPNOTSUPP` for the RTU implementation (though it should be straight forward to implement).

To implement the non-blocking receive, I just added a bool parameter to the main `_modbus_receive_msg` function (defaulting to false for all calls), and add special handling for when it is set to true (only in the TCP backend `receive_nb` function) so as to not break any existing behaviour compatibility.

The `modbus_receive_nb` implementation allows for a return value of -1 with `errno == ETIMEDOUT` after waiting for a message using the context receive timeout value. All other behaviours should be treated as with a call to `modbus_receive`.