### PR TITLE
Need to attach user data to modbus context

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,9 +102,7 @@ AC_LIBMODBUS_CHECK_BUILD_DOC
 AC_CHECK_DECLS([__CYGWIN__])
 
 # Checks for library functions.
-AC_FUNC_FORK
-AC_FUNC_MALLOC
-AC_CHECK_FUNCS([accept4 getaddrinfo gettimeofday inet_ntoa memset select socket strerror strlcpy])
+AC_CHECK_FUNCS([accept4 getaddrinfo gettimeofday inet_ntoa select socket strerror strlcpy])
 
 # Required for MinGW with GCC v4.8.1 on Win7
 AC_DEFINE(WINVER, 0x0501, _)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -60,7 +60,9 @@ TXT3 = \
         modbus_write_bits.txt \
         modbus_write_bit.txt \
         modbus_write_registers.txt \
-        modbus_write_register.txt
+        modbus_write_register.txt \
+        modbus_set_user_data.txt \
+        modbus_get_user_data.txt
 TXT7 = libmodbus.txt
 
 EXTRA_DIST = asciidoc.conf $(TXT3) $(TXT7)

--- a/doc/modbus_get_user_data.txt
+++ b/doc/modbus_get_user_data.txt
@@ -1,0 +1,83 @@
+modbus_set_user_data(1)
+=======================
+
+
+NAME
+----
+modbus_get_user_data - get the user data pointer attached to the context
+
+
+SYNOPSIS
+--------
+*int modbus_get_user_data(modbus_t *'ctx', void **'user_data');*
+
+
+DESCRIPTION
+-----------
+The *modbus_get_user_data()* function shall get the user data pointer in the
+libmodbus context.
+
+This user data has been previously attached to the context by the function
+linkmb:modbus_set_user_data[1].
+
+RETURN VALUE
+------------
+The function shall return 0 if successful. Otherwise it shall return -1 and set
+errno to one of the values defined below.
+
+
+ERRORS
+------
+*EINVAL*::
+The libmodbus context or the user_data pointer are invalid.
+
+
+EXAMPLE
+-------
+[source,c]
+-------------------
+modbus_t *ctx;
+static const char* user_string = "first context";
+
+ctx = modbus_new_rtu("/dev/ttyUSB0", 115200, 'N', 8, 1);
+if (ctx == NULL) {
+    fprintf(stderr, "Unable to create the libmodbus context\n");
+    return -1;
+}
+
+rc = modbus_set_user_data(ctx, (void*)user_string);
+if (rc == -1) {
+    fprintf(stderr, "Invalid slave ID\n");
+    modbus_free(ctx);
+    return -1;
+}
+
+if (modbus_connect(ctx) == -1) {
+    fprintf(stderr, "Connection failed: %s\n", modbus_strerror(errno));
+    modbus_free(ctx);
+    return -1;
+}
+
+(...)
+
+const char* the_user_string;
+
+rc = modbus_get_user_data(ctx, (void**)&the_user_string);
+if (rc == -1) {
+    fprintf(stderr, "Invalid slave ID\n");
+    modbus_free(ctx);
+    return -1;
+} else {
+    printf("The user string is %s\n", the_user_string);
+}
+
+-------------------
+
+SEE ALSO
+--------
+linkmb:modbus_set_user_data[1]
+
+AUTHORS
+-------
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/doc/modbus_get_user_data.txt
+++ b/doc/modbus_get_user_data.txt
@@ -37,11 +37,7 @@ EXAMPLE
 [source,c]
 -------------------
 modbus_t *ctx;
-<<<<<<< HEAD
 static const char* user_string = "first context";
-=======
-static const char* user_string[] = "first context";
->>>>>>> f3436390f8f364496be09a16aad52e1de3870d03
 
 ctx = modbus_new_rtu("/dev/ttyUSB0", 115200, 'N', 8, 1);
 if (ctx == NULL) {

--- a/doc/modbus_set_user_data.txt
+++ b/doc/modbus_set_user_data.txt
@@ -1,0 +1,82 @@
+modbus_set_user_data(1)
+=======================
+
+
+NAME
+----
+modbus_set_user_data - attach a user data pointer to the context
+
+
+SYNOPSIS
+--------
+*int modbus_set_user_data(modbus_t *'ctx', void *'user_data');*
+
+
+DESCRIPTION
+-----------
+The *modbus_set_user_data()* function shall set a user data pointer in the
+libmodbus context.
+
+The user is free to attach the data he wants in the libmodbus context.
+
+RETURN VALUE
+------------
+The function shall return 0 if successful. Otherwise it shall return -1 and set
+errno to one of the values defined below.
+
+
+ERRORS
+------
+*EINVAL*::
+The libmodbus context is invalid.
+
+
+EXAMPLE
+-------
+[source,c]
+-------------------
+modbus_t *ctx;
+static const char* user_string[] = "first context";
+
+ctx = modbus_new_rtu("/dev/ttyUSB0", 115200, 'N', 8, 1);
+if (ctx == NULL) {
+    fprintf(stderr, "Unable to create the libmodbus context\n");
+    return -1;
+}
+
+rc = modbus_set_user_data(ctx, (void*)user_string);
+if (rc == -1) {
+    fprintf(stderr, "Invalid slave ID\n");
+    modbus_free(ctx);
+    return -1;
+}
+
+if (modbus_connect(ctx) == -1) {
+    fprintf(stderr, "Connection failed: %s\n", modbus_strerror(errno));
+    modbus_free(ctx);
+    return -1;
+}
+
+(...)
+
+const char* the_user_string;
+
+rc = modbus_get_user_data(ctx, (void**)&the_user_string);
+if (rc == -1) {
+    fprintf(stderr, "Invalid slave ID\n");
+    modbus_free(ctx);
+    return -1;
+} else {
+    printf("The user string is %s\n", the_user_string);
+}
+
+-------------------
+
+SEE ALSO
+--------
+linkmb:modbus_get_user_data[1]
+
+AUTHORS
+-------
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/doc/modbus_set_user_data.txt
+++ b/doc/modbus_set_user_data.txt
@@ -36,7 +36,7 @@ EXAMPLE
 [source,c]
 -------------------
 modbus_t *ctx;
-static const char* user_string[] = "first context";
+static const char* user_string = "first context";
 
 ctx = modbus_new_rtu("/dev/ttyUSB0", 115200, 'N', 8, 1);
 if (ctx == NULL) {

--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -101,6 +101,7 @@ struct _modbus {
     struct timeval indication_timeout;
     const modbus_backend_t *backend;
     void *backend_data;
+    void *user_data;
 };
 
 void _modbus_init_common(modbus_t *ctx);

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1576,6 +1576,8 @@ void _modbus_init_common(modbus_t *ctx)
 
     ctx->indication_timeout.tv_sec = 0;
     ctx->indication_timeout.tv_usec = 0;
+
+    ctx->user_data = NULL;
 }
 
 /* Define the slave number */
@@ -1708,6 +1710,28 @@ int modbus_set_indication_timeout(modbus_t *ctx, uint32_t to_sec, uint32_t to_us
 
     ctx->indication_timeout.tv_sec = to_sec;
     ctx->indication_timeout.tv_usec = to_usec;
+    return 0;
+}
+
+int modbus_set_user_data(modbus_t *ctx, void *user_data)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    ctx->user_data = user_data;
+    return 0;
+}
+
+int modbus_get_user_data(modbus_t *ctx, void **user_data)
+{
+    if (ctx == NULL || user_data == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *user_data = ctx->user_data;
     return 0;
 }
 

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -193,6 +193,9 @@ MODBUS_API int modbus_set_indication_timeout(modbus_t *ctx, uint32_t to_sec, uin
 
 MODBUS_API int modbus_get_header_length(modbus_t *ctx);
 
+MODBUS_API int modbus_set_user_data(modbus_t *ctx, void *user_data);
+MODBUS_API int modbus_get_user_data(modbus_t *ctx, void **user_data);
+
 MODBUS_API int modbus_connect(modbus_t *ctx);
 MODBUS_API void modbus_close(modbus_t *ctx);
 


### PR DESCRIPTION
Hi Stephane

We have hardware configurations that require multiple modbus rtu networks each using a user RTS management (OMG!)
In order to discriminate the modbus network in the function set_rts (set with modbus_rtu_set_custom_rts), we added the 2 functions **modbus_set_user_data** and **modbus_get_user_data** to libmodbus.

We use them to attach a pointer to our structures describing the network.

As we think these functions may be usefull to other users, here is the matching pull request 
