### PR TITLE
Allow to choose the RTS activation level for RS485

### DIFF
--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -910,18 +910,23 @@ int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode)
         modbus_rtu_t *ctx_rtu = ctx->backend_data;
         struct serial_rs485 rs485conf;
 
-        if (mode == MODBUS_RTU_RS485) {
+        if ( (mode == MODBUS_RTU_RS485) || 
+              (mode == MODBUS_RTU_RS485_RTS_ON_SEND) ) {
             // Get
             if (ioctl(ctx->s, TIOCGRS485, &rs485conf) < 0) {
                 return -1;
             }
             // Set
             rs485conf.flags |= SER_RS485_ENABLED;
+            if (mode == MODBUS_RTU_RS485) {
+                rs485conf.flags |= SER_RS485_RTS_AFTER_SEND;
+            } else {
+                rs485conf.flags |= SER_RS485_RTS_ON_SEND;
+            }
             if (ioctl(ctx->s, TIOCSRS485, &rs485conf) < 0) {
                 return -1;
             }
-
-            ctx_rtu->serial_mode = MODBUS_RTU_RS485;
+            ctx_rtu->serial_mode = mode;
             return 0;
         } else if (mode == MODBUS_RTU_RS232) {
             /* Turn off RS485 mode only if required */

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -21,6 +21,10 @@ MODBUS_API modbus_t* modbus_new_rtu(const char *device, int baud, char parity,
 
 #define MODBUS_RTU_RS232 0
 #define MODBUS_RTU_RS485 1
+/* RS485 set logical level for RTS pin equal to 0 after sending (RS485 default) */
+#define MODBUS_RTU_RS485_RTS_AFTER_SEND MODBUS_RTU_RS485 
+/* RS485 set logical level for RTS pin equal to 0 when sending */
+#define MODBUS_RTU_RS485_RTS_ON_SEND 2
 
 MODBUS_API int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode);
 MODBUS_API int modbus_rtu_get_serial_mode(modbus_t *ctx);


### PR DESCRIPTION
Hello Stephane,
I created mbpoll (https://github.com/epsilonrt/mbpoll) to provide an open source tool for controlling MODBUS slaves.
This program uses libmodbus. It has some success, especially on ARM platforms (but it is multiplatform).
Under certain circumstances, it is necessary to control the signal DE of the RS485 drivers in the low state. It depends on the electronic structure of the RS485 part.
So I modified your code to add this possibility.
I now wish to propose mbpoll as a debian package and I must of course separate your code from mine.
I propose you this modification hoping that you will agree.
Thank you.
Best Regards