### PR TITLE
Add modbus_send_raw_msg api function

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -162,6 +162,49 @@ static unsigned int compute_response_length_from_request(modbus_t *ctx, uint8_t 
     return offset + length + ctx->backend->checksum_length;
 }
 
+/* Sends a raw request/response */
+int modbus_send_raw_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
+{
+    int rc;
+    int i;
+
+    if (ctx->debug) {
+        for (i = 0; i < msg_length; i++)
+            printf("[%.2X]", msg[i]);
+        printf("\n");
+    }
+
+    /* In recovery mode, the write command will be issued until to be
+       successful! Disabled by default. */
+    do {
+        rc = ctx->backend->send(ctx, msg, msg_length);
+        if (rc == -1) {
+            _error_print(ctx, NULL);
+            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) {
+                int saved_errno = errno;
+
+                if ((errno == EBADF || errno == ECONNRESET || errno == EPIPE)) {
+                    modbus_close(ctx);
+                    _sleep_response_timeout(ctx);
+                    modbus_connect(ctx);
+                } else {
+                    _sleep_response_timeout(ctx);
+                    modbus_flush(ctx);
+                }
+                errno = saved_errno;
+            }
+        }
+    } while ((ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) &&
+             rc == -1);
+
+    if (rc > 0 && rc != msg_length) {
+        errno = EMBBADDATA;
+        return -1;
+    }
+
+    return rc;
+}
+
 /* Sends a request/response */
 static int send_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
 {

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -238,6 +238,7 @@ MODBUS_API int modbus_reply(modbus_t *ctx, const uint8_t *req,
 MODBUS_API int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,
                                       unsigned int exception_code);
 
+MODBUS_API int modbus_send_raw_msg(modbus_t *ctx, uint8_t *msg, int msg_length);
 /**
  * UTILS FUNCTIONS
  **/


### PR DESCRIPTION
Add a modbus_send_raw_msg api function，for the reason that sending a raw message with serial port is requested. Sometimes we will send message use serial port to the device using modbus and not using modbus protocol，in this case we can use this function. 