### PR TITLE
Add support for local echo suppression workaround

### DIFF
--- a/doc/modbus_rtu_get_suppress_echo.txt
+++ b/doc/modbus_rtu_get_suppress_echo.txt
@@ -1,0 +1,47 @@
+modbus_rtu_get_suppress_echo(3)
+===============================
+
+
+NAME
+----
+modbus_rtu_get_suppress_echo - get local echo suppression status
+
+
+SYNOPSIS
+--------
+*int modbus_rtu_get_suppress_echo(modbus_t *'ctx');*
+
+
+DESCRIPTION
+-----------
+The _modbus_rtu_get_suppress_echo()_ function shall return the current
+enabled/disable state of local echo suppression workaround of
+the libmodbus context 'ctx'.
+
+This function can only be used with a context using a RTU backend.
+
+
+RETURN VALUE
+------------
+The _modbus_rtu_get_suppress_echo()_ function shall return 0 if workaround
+is disable, 1 when it is enabled.
+Otherwise it shall return -1 and set errno.
+
+
+ERRORS
+------
+*EINVAL*::
+The libmodbus backend is not RTU.
+
+
+SEE ALSO
+--------
+linkmb:modbus_rtu_set_suppress_echo[3]
+
+
+AUTHORS
+-------
+Michael Heimpold <mhei@heimpold.de>
+
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/doc/modbus_rtu_set_suppress_echo.txt
+++ b/doc/modbus_rtu_set_suppress_echo.txt
@@ -1,0 +1,53 @@
+modbus_rtu_set_suppress_echo(3)
+===============================
+
+
+NAME
+----
+modbus_rtu_set_suppress_echo - enable/disable local echo suppression
+
+
+SYNOPSIS
+--------
+*int modbus_rtu_set_suppress_echo(modbus_t *'ctx', bool 'on');*
+
+
+DESCRIPTION
+-----------
+The _modbus_rtu_set_suppress_echo()_ function shall enable or disable
+local echo suppression workaround of the libmodbus context 'ctx'.
+
+Enable this on hardware platforms which locally echo all bytes which
+are transmitted. When enabled, it will immediately receive the self-made
+packet to clean up the incoming buffer.
+
+Do not enable it on hardware platforms which do _not_ echo or when
+local echo is turned off. Otherwise valid response packets are wrongly
+removed from incoming buffer.
+
+This function can only be used with a context using a RTU backend.
+
+
+RETURN VALUE
+------------
+The _modbus_rtu_set_suppress_echo()_ function shall return 0 if successful.
+Otherwise it shall return -1 and set errno.
+
+
+ERRORS
+------
+*EINVAL*::
+The libmodbus backend is not RTU.
+
+
+SEE ALSO
+--------
+linkmb:modbus_rtu_get_suppress_echo[3]
+
+
+AUTHORS
+-------
+Michael Heimpold <mhei@heimpold.de>
+
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -71,6 +71,9 @@ typedef struct _modbus_rtu {
 #endif
     /* To handle many slaves on the same link */
     int confirmation_to_ignore;
+    /* software-side local echo suppression of sent bytes since hardware
+     * does not support it or is configured to not do it */
+    bool is_echo_suppressing;
 } modbus_rtu_t;
 
 #endif /* MODBUS_RTU_PRIVATE_H */

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -7,6 +7,7 @@
 #ifndef MODBUS_RTU_H
 #define MODBUS_RTU_H
 
+#include <stdbool.h>
 #include "modbus.h"
 
 MODBUS_BEGIN_DECLS
@@ -36,6 +37,9 @@ MODBUS_API int modbus_rtu_set_custom_rts(modbus_t *ctx, void (*set_rts) (modbus_
 
 MODBUS_API int modbus_rtu_set_rts_delay(modbus_t *ctx, int us);
 MODBUS_API int modbus_rtu_get_rts_delay(modbus_t *ctx);
+
+MODBUS_API int modbus_rtu_set_suppress_echo(modbus_t *ctx, bool on);
+MODBUS_API int modbus_rtu_get_suppress_echo(modbus_t *ctx);
 
 MODBUS_END_DECLS
 


### PR DESCRIPTION
Usually, RS-485 hardware for half-duplex connections is designed to
suppress self-generated TX traffic on the RX side. This usually
achived by controlling the Receive Enable pin of the driver with
the same signal which toggles the Transmit Enable pin (traditionally
one pin uses an inverted signal, so this is really easy to implement).

However, on - let's call this 'buggy' -  boards which enable RX side
unconditionally, you'll see all of your outgoing traffic also on
incoming side. So to filter out this expected but unwanted traffic
we could simply flush the incoming queue. But this way, we could
drop erroneously bytes of the legitimate response from a peer, e.g.
if the peer answers very quickly.

This approach makes use of the knowledge how many bytes are expected
and thus must be dropped. Do it directly in the transmitting function
to prevent handing over the expected byte count through modbus context.

Also add required functions to enable/disable this workaround and
provide API documentation.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>