### PR TITLE
Flush buffer before send

### DIFF
--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -58,6 +58,8 @@
 #include "modbus-tcp.h"
 #include "modbus-tcp-private.h"
 
+static int _modbus_tcp_flush(modbus_t *ctx);
+
 #ifdef OS_WIN32
 static int _modbus_tcp_init_win32(void)
 {
@@ -169,6 +171,9 @@ static ssize_t _modbus_tcp_send(modbus_t *ctx, const uint8_t *req, int req_lengt
        Requests not to send SIGPIPE on errors on stream oriented
        sockets when the other end breaks the connection.  The EPIPE
        error is still returned. */
+    
+    _modbus_tcp_flush(ctx);
+    
     return send(ctx->s, (const char *)req, req_length, MSG_NOSIGNAL);
 }
 


### PR DESCRIPTION
This is to help avoid transaction IDs getting out of wack and failing every time on that check after a connection error.

We are testing to a socomec device on a 3g modem, using these https://hub.docker.com/u/edgepro/ docker containers (everything but mb-mqtt).

The same test can be completed by ifdown the ubuntu running docker with the emulated slave container and trying to make a request then running ifup after that you will always get a invalid data error back.  The flush before send fixes the issue, if their is a better way to fix this problem with transaction IDs getting confused after error possibly due to flaky comms please advise. I am usualy a C# developer so this is quite new to me. Thanks