### PR TITLE
modbus_mapping_t is now a named typedef (to allow forward declaration)

### DIFF
--- a/src/modbus.h
+++ b/src/modbus.h
@@ -154,7 +154,7 @@ extern const unsigned int libmodbus_version_micro;
 
 typedef struct _modbus modbus_t;
 
-typedef struct {
+typedef struct _modbus_mapping_t {
     int nb_bits;
     int start_bits;
     int nb_input_bits;


### PR DESCRIPTION
A little edit to allow forward declation of modbus_mapping_t