### PR TITLE
Remove redundant check and guard debug output

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1335,17 +1335,6 @@ static int read_registers(modbus_t *ctx, int function, int addr, int nb, uint16_
     uint8_t req[_MIN_REQ_LENGTH];
     uint8_t rsp[MAX_MESSAGE_LENGTH];
 
-    if (nb > MODBUS_MAX_READ_REGISTERS) {
-        if (ctx->debug) {
-            fprintf(stderr,
-                    "ERROR Too many registers requested (%d > %d)\n",
-                    nb,
-                    MODBUS_MAX_READ_REGISTERS);
-        }
-        errno = EMBMDATA;
-        return -1;
-    }
-
     req_length = ctx->backend->build_request_basis(ctx, function, addr, nb, req);
 
     rc = send_msg(ctx, req, req_length);


### PR DESCRIPTION
I found two minor issues:
- we can remove a redundant check
- ~print error message only when debug output is enabled to be consistent with other functions~

Edit: updated description after force-push (second issue was meanwhile fixed, so I dropped the commit)
