### PR TITLE
Fixed MODBUS_GET_* macros in case of negative values

### DIFF
--- a/src/modbus.h
+++ b/src/modbus.h
@@ -245,12 +245,12 @@ MODBUS_API int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,
 #define MODBUS_GET_HIGH_BYTE(data) (((data) >> 8) & 0xFF)
 #define MODBUS_GET_LOW_BYTE(data) ((data) & 0xFF)
 #define MODBUS_GET_INT64_FROM_INT16(tab_int16, index) \
-    (((int64_t)tab_int16[(index)    ] << 48) + \
-     ((int64_t)tab_int16[(index) + 1] << 32) + \
-     ((int64_t)tab_int16[(index) + 2] << 16) + \
+    (((int64_t)tab_int16[(index)    ] << 48) | \
+     ((int64_t)tab_int16[(index) + 1] << 32) | \
+     ((int64_t)tab_int16[(index) + 2] << 16) | \
       (int64_t)tab_int16[(index) + 3])
-#define MODBUS_GET_INT32_FROM_INT16(tab_int16, index) ((tab_int16[(index)] << 16) + tab_int16[(index) + 1])
-#define MODBUS_GET_INT16_FROM_INT8(tab_int8, index) ((tab_int8[(index)] << 8) + tab_int8[(index) + 1])
+#define MODBUS_GET_INT32_FROM_INT16(tab_int16, index) ((tab_int16[(index)] << 16) | tab_int16[(index) + 1])
+#define MODBUS_GET_INT16_FROM_INT8(tab_int8, index) ((tab_int8[(index)] << 8) | tab_int8[(index) + 1])
 #define MODBUS_SET_INT16_TO_INT8(tab_int8, index, value) \
     do { \
         tab_int8[(index)] = (value) >> 8;  \


### PR DESCRIPTION
In case resulting value should be negative it is incorrect to use '+' operator to construct it from pieces, because highest bytes will result in negative number after bitwise shift while others will stay positive. Replacing addition with '|' should solve the issue.