### PR TITLE
Added function "modbus_read_device_information_object"

### DIFF
--- a/doc/modbus_read_device_information_object.txt
+++ b/doc/modbus_read_device_information_object.txt
@@ -1,0 +1,88 @@
+modbus_read_device_information_object(3)
+========================================
+
+
+NAME
+----
+modbus_read_device_information_object - retrieving device information
+
+
+SYNOPSIS
+--------
+*int modbus_read_device_information_object(modbus_t *ctx, unsigned char object_id, uint16_t *dest);*
+
+
+DESCRIPTION
+-----------
+The *modbus_read_device_information_object()* function reads the content
+of a single object within the device identification registers.
+There are several standardized objects:
+
+Object ID | Type     | Object Name         | Data Type    | Mandatory
+----------+----------+---------------------+--------------+----------
+ 0x00     | Basic    | VendorName          | ASCII String | yes
+ 0x01     | Basic    | ProductCode         | ASCII String | yes
+ 0x02     | Basic    | MajorMinorRevision  | ASCII String | yes
+ 0x03     | Regular  | VendorUrl           | ASCII String | no
+ 0x04     | Regular  | ProductName         | ASCII String | no
+ 0x05     | Regular  | ModelName           | ASCII String | no
+ 0x06     | Regular  | UserApplicationName | ASCII String | no
+ 0x80 + n | Extended | Device specific     | Binary       | no
+ 
+The result of reading is stored in _dest_ array as word values (16 bits).
+
+You must take care to allocate enough memory to store the results in _dest_
+(130 * sizeof(uint16_t) will always be enough).
+
+The function uses the Modbus function code 0x2B (read device identification).
+
+
+RETURN VALUE
+------------
+The function returns the number of read bytes if successful. 
+Otherwise it shall return -1 and set errno.
+
+
+ERRORS
+------
+
+
+EXAMPLE
+-------
+[source,c]
+-------------------
+modbus_t *ctx;
+uint16_t vendor_name[130];
+int rc;
+int i;
+
+ctx = modbus_new_tcp("127.0.0.1", 1502);
+if (modbus_connect(ctx) == -1) {
+    fprintf(stderr, "Connection failed: %s\n", modbus_strerror(errno));
+    modbus_free(ctx);
+    return -1;
+}
+
+rc = modbus_read_device_information_object(ctx, 0x04, vendor_name);
+if (rc == -1) {
+    fprintf(stderr, "%s\n", modbus_strerror(errno));
+    return -1;
+}
+
+printf("Vendor Name: '%s'", (char*)vendor_name);
+
+modbus_close(ctx);
+modbus_free(ctx);
+-------------------
+
+
+SEE ALSO
+--------
+
+
+AUTHORS
+-------
+This function was introduced by Oliver Schwaneberg
+<oliver.schwaneberg@gmail.com>
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -70,8 +70,18 @@ MODBUS_BEGIN_DECLS
 #define MODBUS_FC_REPORT_SLAVE_ID           0x11
 #define MODBUS_FC_MASK_WRITE_REGISTER       0x16
 #define MODBUS_FC_WRITE_AND_READ_REGISTERS  0x17
+#define MODBUS_FC_READ_DEVICE_INFORMATION   0x2B
 
 #define MODBUS_BROADCAST_ADDRESS    0
+
+/* Modbus device information object codes */
+#define MODBUS_OBJID_VENDORNAME             0x00
+#define MODBUS_OBJID_PRODUCTCODE            0x01
+#define MODBUS_OBJID_MAJOR_MINOR_REVISION   0x02
+#define MODBUS_OBJID_VENDOR_URL             0x03
+#define MODBUS_OBJID_PRODUCTNAME            0x04
+#define MODBUS_OBJID_MODELNAME              0x05
+#define MODBUS_OBJID_USERAPPLICATION        0x06
 
 /* Modbus_Application_Protocol_V1_1b.pdf (chapter 6 section 1 page 12)
  * Quantity of Coils to read (2 bytes): 1 to 2000 (0x7D0)
@@ -203,6 +213,7 @@ MODBUS_API int modbus_set_debug(modbus_t *ctx, int flag);
 
 MODBUS_API const char *modbus_strerror(int errnum);
 
+MODBUS_API int modbus_read_device_information_object(modbus_t *ctx, unsigned char object_id, uint16_t *dest);
 MODBUS_API int modbus_read_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest);
 MODBUS_API int modbus_read_input_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest);
 MODBUS_API int modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t *dest);


### PR DESCRIPTION
This PR adds a new function to access the built in device information from Modbus devices.

Changes:
- A new function code "MODBUS_FC_READ_DEVICE_INFORMATION" was added.
- Device information object codes were added, e.g. MODBUS_OBJID_VENDORNAME.
- Function "modbus_read_device_information_object(modbus_t *ctx, unsigned char object_id, char* dest);" was added.
- Several internal functions were extended to handle the new function code.

Notes:
I successfully tested to code with a server that uses big endian word and byte order. Therefore, the mapping in modbus.c:1432 might be wrong for clients with little endian word order, depending on how strings are handled.

Signed-off-by: Oliver Schwaneberg <oliver.schwaneberg@gmail.com>