### PR TITLE
Fix URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ respects the Modbus protocol. This library can use a serial port or an Ethernet
 connection.
 
 The functions included in the library have been derived from the Modicon Modbus
-Protocol Reference Guide which can be obtained from Schneider at
-[www.schneiderautomation.com](http://www.schneiderautomation.com).
+Protocol Reference Guide which can be obtained from [www.modbus.org](http://www.modbus.org).
 
 The license of libmodbus is *LGPL v2.1 or later*.
 


### PR DESCRIPTION
Schneider Automation has become Schneider Electric, which refers to modbus.org.