### PR TITLE
Second approach for implementing 'RTU over RTP'

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -19,6 +19,8 @@ TXT3 = \
         modbus_mapping_new_start_address.txt \
         modbus_mask_write_register.txt \
         modbus_new_rtu.txt \
+        modbus_new_rtutcp_pi.txt \
+        modbus_new_rtutcp.txt \
         modbus_new_tcp_pi.txt \
         modbus_new_tcp.txt \
         modbus_read_bits.txt \

--- a/doc/libmodbus.txt
+++ b/doc/libmodbus.txt
@@ -108,6 +108,31 @@ Create a Modbus TCP context::
     linkmb:modbus_new_tcp_pi[3]
 
 
+RTU over TCP (IPv4) Context
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The RTU over TCP backend implements a Modbus variant used for communications over
+TCP/IPv4 networks. It tunnels Modbus RTU messages over TCP.
+
+Analogue to the RTU Context before sending a message, you must set the slave (receiver) with
+linkmb:modbus_set_slave[3]. If you're running a slave, its slave number will be
+used to filter received messages.
+
+Create a Modbus RTU over TCP context::
+    linkmb:modbus_new_rtutcp[3]
+
+
+RTU over TCP PI (IPv4 and IPv6) Context
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The RTU over TCP PI (Protocol Indepedent) backend implements a Modbus variant used for
+communications over TCP IPv4 and IPv6 networks. It tunnels Modbus RTU messages over TCP.
+
+Contrary to the RTU over TCP IPv4 only backend, the RTU over TCP PI backend offers hostname
+resolution but it consumes about 1Kb of additional memory.
+
+Create a Modbus RTU over TCP context::
+    linkmb:modbus_new_rtutcp_pi[3]
+
+
 Common
 ^^^^^^
 Before using any libmodbus functions, the caller must allocate and initialize a

--- a/doc/modbus_new_rtu.txt
+++ b/doc/modbus_new_rtu.txt
@@ -82,6 +82,9 @@ if (modbus_connect(ctx) == -1) {
 SEE ALSO
 --------
 linkmb:modbus_new_tcp[3]
+linkmb:modbus_new_tcp_pi[3]
+linkmb:modbus_new_rtutcp[3]
+linkmb:modbus_new_rtutcp_pi[3]
 linkmb:modbus_free[3]
 
 

--- a/doc/modbus_new_rtutcp.txt
+++ b/doc/modbus_new_rtutcp.txt
@@ -1,0 +1,75 @@
+modbus_new_rtutcp(3)
+=================
+
+
+NAME
+----
+modbus_new_rtutcp - create a libmodbus context for RTU over TCP/IPv4
+
+
+SYNOPSIS
+--------
+*modbus_t *modbus_new_rtutcp(const char *'ip', int 'port');*
+
+
+DESCRIPTION
+-----------
+The _modbus_new_rtutcp()_ function shall allocate and initialize a modbus_t
+structure to communicate with a Modbus RTU over TCP/IPv4 server.
+
+The _ip_ argument specifies the IP address of the server to which the client
+wants to establish a connection. A NULL value can be used to listen any addresses in
+server mode.
+
+The _port_ argument is the TCP port to use. Set the port to
+_MODBUS_RTUTCP_DEFAULT_PORT_ to use the default one (502). It’s convenient to use a
+port number greater than or equal to 1024 because it’s not necessary to have
+administrator privileges.
+
+
+RETURN VALUE
+------------
+The function shall return a pointer to a *modbus_t* structure if
+successful. Otherwise it shall return NULL and set errno to one of the values
+defined below.
+
+
+ERRORS
+------
+*EINVAL*::
+An invalid IP address was given.
+
+*ENOMEM*::
+Out of memory. Possibly, the application hits its memory limit and/or whole
+system is running out of memory.
+
+
+EXAMPLE
+-------
+[source,c]
+-------------------
+modbus_t *ctx;
+
+ctx = modbus_new_rtutcp("127.0.0.1", 1502);
+if (ctx == NULL) {
+    fprintf(stderr, "Unable to allocate libmodbus context\n");
+    return -1;
+}
+
+if (modbus_connect(ctx) == -1) {
+    fprintf(stderr, "Connection failed: %s\n", modbus_strerror(errno));
+    modbus_free(ctx);
+    return -1;
+}
+-------------------
+
+SEE ALSO
+--------
+linkmb:modbus_rtutcp_listen[3]
+linkmb:modbus_free[3]
+
+
+AUTHORS
+-------
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/doc/modbus_new_rtutcp_pi.txt
+++ b/doc/modbus_new_rtutcp_pi.txt
@@ -1,0 +1,77 @@
+modbus_new_rtutcp_pi(3)
+====================
+
+
+NAME
+----
+modbus_new_rtutcp_pi - create a libmodbus context for RTU over TCP Protocol Independent
+
+
+SYNOPSIS
+--------
+*modbus_t *modbus_new_rtutcp_pi(const char *'node', const char *'service');*
+
+
+DESCRIPTION
+-----------
+The _modbus_new_rtutcp_pi()_ function shall allocate and initialize a modbus_t
+structure to communicate with a Modbus RTU over TCP IPv4 or Ipv6 server.
+
+The _node_ argument specifies the host name or IP address of the host to connect
+to, eg. "192.168.0.5" , "::1" or "server.com". A NULL value can be used to
+listen any addresses in server mode.
+
+The _service_ argument is the service name/port number to connect to. To use the
+default Modbus port use the string "502". On many Unix systems, it’s
+convenient to use a port number greater than or equal to 1024 because it’s not
+necessary to have administrator privileges.
+
+
+RETURN VALUE
+------------
+The function shall return a pointer to a *modbus_t* structure if
+successful. Otherwise it shall return NULL and set errno to one of the values
+defined below.
+
+
+ERRORS
+------
+*EINVAL*::
+The node string is empty or has been truncated. The service string is empty or
+has been truncated.
+
+*ENOMEM*::
+Out of memory. Possibly, the application hits its memory limit and/or whole
+system is running out of memory.
+
+
+EXAMPLE
+-------
+[source,c]
+-------------------
+modbus_t *ctx;
+
+ctx = modbus_new_rtutcp_pi("::1", "1502");
+if (ctx == NULL) {
+    fprintf(stderr, "Unable to allocate libmodbus context\n");
+    return -1;
+}
+
+if (modbus_connect(ctx) == -1) {
+    fprintf(stderr, "Connection failed: %s\n", modbus_strerror(errno));
+    modbus_free(ctx);
+    return -1;
+}
+-------------------
+
+SEE ALSO
+--------
+linkmb:modbus_new_rtutcp[3]
+linkmb:modbus_rtutcp_pi_listen[3]
+linkmb:modbus_free[3]
+
+
+AUTHORS
+-------
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,9 @@ libmodbus_la_SOURCES = \
         modbus-tcp.c \
         modbus-tcp.h \
         modbus-tcp-private.h \
+        modbus-rtutcp.c \
+        modbus-rtutcp.h \
+        modbus-rtutcp-private.h \
         modbus-version.h
 
 libmodbus_la_LDFLAGS = -no-undefined \
@@ -35,7 +38,7 @@ endif
 
 # Header files to install
 libmodbusincludedir = $(includedir)/modbus
-libmodbusinclude_HEADERS = modbus.h modbus-version.h modbus-rtu.h modbus-tcp.h
+libmodbusinclude_HEADERS = modbus.h modbus-version.h modbus-rtu.h modbus-tcp.h modbus-rtutcp.h
 
 DISTCLEANFILES = modbus-version.h
 EXTRA_DIST += modbus-version.h.in

--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -41,7 +41,8 @@ MODBUS_BEGIN_DECLS
 
 typedef enum {
     _MODBUS_BACKEND_TYPE_RTU=0,
-    _MODBUS_BACKEND_TYPE_TCP
+    _MODBUS_BACKEND_TYPE_TCP,
+    _MODBUS_BACKEND_TYPE_RTUTCP
 } modbus_backend_type_t;
 
 /*

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -73,4 +73,13 @@ typedef struct _modbus_rtu {
     int confirmation_to_ignore;
 } modbus_rtu_t;
 
+int _modbus_rtu_build_request_basis(modbus_t *ctx, int function,
+                                    int addr, int nb,
+                                    uint8_t *req);
+int _modbus_rtu_build_response_basis(sft_t *sft, uint8_t *rsp);
+int _modbus_rtu_prepare_response_tid(const uint8_t *req, int *req_length);
+int _modbus_rtu_send_msg_pre(uint8_t *req, int req_length);
+int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
+                                const int msg_length);
+
 #endif /* MODBUS_RTU_PRIVATE_H */

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -103,7 +103,7 @@ static int _modbus_set_slave(modbus_t *ctx, int slave)
 }
 
 /* Builds a RTU request header */
-static int _modbus_rtu_build_request_basis(modbus_t *ctx, int function,
+int _modbus_rtu_build_request_basis(modbus_t *ctx, int function,
                                            int addr, int nb,
                                            uint8_t *req)
 {
@@ -119,7 +119,7 @@ static int _modbus_rtu_build_request_basis(modbus_t *ctx, int function,
 }
 
 /* Builds a RTU response header */
-static int _modbus_rtu_build_response_basis(sft_t *sft, uint8_t *rsp)
+int _modbus_rtu_build_response_basis(sft_t *sft, uint8_t *rsp)
 {
     /* In this case, the slave is certainly valid because a check is already
      * done in _modbus_rtu_listen */
@@ -129,7 +129,7 @@ static int _modbus_rtu_build_response_basis(sft_t *sft, uint8_t *rsp)
     return _MODBUS_RTU_PRESET_RSP_LENGTH;
 }
 
-static uint16_t crc16(uint8_t *buffer, uint16_t buffer_length)
+uint16_t crc16(uint8_t *buffer, uint16_t buffer_length)
 {
     uint8_t crc_hi = 0xFF; /* high CRC byte initialized */
     uint8_t crc_lo = 0xFF; /* low CRC byte initialized */
@@ -145,14 +145,14 @@ static uint16_t crc16(uint8_t *buffer, uint16_t buffer_length)
     return (crc_hi << 8 | crc_lo);
 }
 
-static int _modbus_rtu_prepare_response_tid(const uint8_t *req, int *req_length)
+int _modbus_rtu_prepare_response_tid(const uint8_t *req, int *req_length)
 {
     (*req_length) -= _MODBUS_RTU_CHECKSUM_LENGTH;
     /* No TID */
     return 0;
 }
 
-static int _modbus_rtu_send_msg_pre(uint8_t *req, int req_length)
+int _modbus_rtu_send_msg_pre(uint8_t *req, int req_length)
 {
     uint16_t crc = crc16(req, req_length);
     req[req_length++] = crc >> 8;
@@ -356,7 +356,7 @@ static int _modbus_rtu_pre_check_confirmation(modbus_t *ctx, const uint8_t *req,
 /* The check_crc16 function shall return 0 is the message is ignored and the
    message length if the CRC is valid. Otherwise it shall return -1 and set
    errno to EMBBADCRC. */
-static int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
+int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
                                        const int msg_length)
 {
     uint16_t crc_calculated;
@@ -386,7 +386,7 @@ static int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
         }
 
         if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_PROTOCOL) {
-            _modbus_rtu_flush(ctx);
+            ctx->backend->flush(ctx);
         }
         errno = EMBBADCRC;
         return -1;

--- a/src/modbus-rtutcp-private.h
+++ b/src/modbus-rtutcp-private.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#ifndef MODBUS_RTUTCP_PRIVATE_H
+#define MODBUS_RTUTCP_PRIVATE_H
+
+#include "modbus-rtu-private.h"
+#include "modbus-tcp-private.h"
+
+#define _MODBUS_RTUTCP_HEADER_LENGTH      _MODBUS_RTU_HEADER_LENGTH
+
+#define _MODBUS_RTUTCP_CHECKSUM_LENGTH     _MODBUS_RTU_CHECKSUM_LENGTH
+
+typedef struct _modbus_rtutcp {
+    modbus_tcp_t base;
+} modbus_rtutcp_t;
+
+typedef struct _modbus_rtutcp_pi {
+    modbus_tcp_pi_t base;
+} modbus_rtutcp_pi_t;
+
+#endif /* MODBUS_RTUTCP_PRIVATE_H */

--- a/src/modbus-rtutcp.c
+++ b/src/modbus-rtutcp.c
@@ -1,0 +1,362 @@
+/*
+ * Copyright © 2001-2013 Stéphane Raimbault <stephane.raimbault@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#if defined(_WIN32)
+# define OS_WIN32
+/* ws2_32.dll has getaddrinfo and freeaddrinfo on Windows XP and later.
+ * minwg32 headers check WINVER before allowing the use of these */
+# ifndef WINVER
+#   define WINVER 0x0501
+# endif
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#if defined(_WIN32)
+/* Already set in modbus-tcp.h but it seems order matters in VS2005 */
+# include <winsock2.h>
+# include <ws2tcpip.h>
+#else
+# include <sys/socket.h>
+# include <sys/ioctl.h>
+
+#if defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ < 5)
+# define OS_BSD
+# include <netinet/in_systm.h>
+#endif
+
+# include <netinet/in.h>
+# include <netinet/ip.h>
+# include <netinet/tcp.h>
+# include <arpa/inet.h>
+# include <netdb.h>
+#endif
+
+#include "modbus-private.h"
+
+#include "modbus-rtutcp.h"
+#include "modbus-rtutcp-private.h"
+
+static int _modbus_set_slave(modbus_t *ctx, int slave)
+{
+    /* Broadcast address is 0 (MODBUS_BROADCAST_ADDRESS) */
+    if (slave >= 0 && slave <= 247) {
+        ctx->slave = slave;
+    } else {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return 0;
+}
+
+static int _modbus_rtutcp_build_request_basis(modbus_t *ctx, int function,
+                                    int addr, int nb,
+                                    uint8_t *req)
+{
+    return _modbus_rtu_build_request_basis(ctx, function, addr, nb, req);
+}
+
+static int _modbus_rtutcp_build_response_basis(sft_t *sft, uint8_t *rsp)
+{
+    return _modbus_rtu_build_response_basis(sft, rsp);
+}
+
+static int _modbus_rtutcp_prepare_response_tid(const uint8_t *req, int *req_length)
+{
+    return _modbus_rtu_prepare_response_tid(req, req_length);
+}
+
+static int _modbus_rtutcp_send_msg_pre(uint8_t *req, int req_length)
+{
+    return _modbus_rtu_send_msg_pre(req, req_length);
+}
+
+static ssize_t _modbus_rtutcp_send(modbus_t *ctx, const uint8_t *req, int req_length)
+{
+    return _modbus_tcp_send(ctx, req, req_length);
+}
+
+static int _modbus_rtutcp_receive(modbus_t *ctx, uint8_t *req)
+{
+    return _modbus_tcp_receive(ctx, req);
+}
+
+static ssize_t _modbus_rtutcp_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length)
+{
+    return _modbus_tcp_recv(ctx, rsp, rsp_length);
+}
+
+/* The check_crc16 function shall return the message length if the CRC is
+   valid. Otherwise it shall return -1 and set errno to EMBADCRC. */
+static int _modbus_rtutcp_check_integrity(modbus_t *ctx, uint8_t *msg,
+                                const int msg_length)
+{
+    return _modbus_rtu_check_integrity(ctx, msg, msg_length);
+}
+
+static int _modbus_rtutcp_connect(modbus_t *ctx)
+{
+    return _modbus_tcp_connect(ctx);
+}
+
+static int _modbus_rtutcp_pi_connect(modbus_t *ctx)
+{
+    return _modbus_tcp_pi_connect(ctx);
+}
+
+static void _modbus_rtutcp_close(modbus_t *ctx)
+{
+    _modbus_tcp_close(ctx);
+}
+
+static int _modbus_rtutcp_flush(modbus_t *ctx)
+{
+    int rc;
+    int rc_sum = 0;
+
+    do {
+        /* Extract the garbage from the socket */
+        char devnull[MODBUS_RTUTCP_MAX_ADU_LENGTH];
+#ifndef OS_WIN32
+        rc = recv(ctx->s, devnull, MODBUS_RTUTCP_MAX_ADU_LENGTH, MSG_DONTWAIT);
+#else
+        /* On Win32, it's a bit more complicated to not wait */
+        fd_set rfds;
+        struct timeval tv;
+
+        tv.tv_sec = 0;
+        tv.tv_usec = 0;
+        FD_ZERO(&rfds);
+        FD_SET(ctx->s, &rfds);
+        rc = select(ctx->s+1, &rfds, NULL, NULL, &tv);
+        if (rc == -1) {
+            return -1;
+        }
+
+        if (rc == 1) {
+            /* There is data to flush */
+            rc = recv(ctx->s, devnull, MODBUS_RTUTCP_MAX_ADU_LENGTH, 0);
+        }
+#endif
+        if (rc > 0) {
+            rc_sum += rc;
+        }
+    } while (rc == MODBUS_RTUTCP_MAX_ADU_LENGTH);
+
+    return rc_sum;
+}
+
+int modbus_rtutcp_listen(modbus_t *ctx, int nb_connection)
+{
+    return modbus_tcp_listen(ctx, nb_connection);
+}
+
+int modbus_rtutcp_pi_listen(modbus_t *ctx, int nb_connection)
+{
+    return modbus_tcp_pi_listen(ctx, nb_connection);
+}
+
+/* On success, the function return a non-negative integer that is a descriptor
+   for the accepted socket. On error, -1 is returned, and errno is set
+   appropriately. */
+int modbus_rtutcp_accept(modbus_t *ctx, int *socket)
+{
+    return modbus_tcp_accept(ctx, socket);
+}
+
+int modbus_rtutcp_pi_accept(modbus_t *ctx, int *socket)
+{
+    return modbus_tcp_pi_accept(ctx, socket);
+}
+
+static int _modbus_rtutcp_select(modbus_t *ctx, fd_set *rfds, struct timeval *tv, int length_to_read)
+{
+    return _modbus_tcp_select(ctx, rfds, tv, length_to_read);
+}
+
+static void _modbus_rtutcp_free(modbus_t *ctx) {
+    free(ctx->backend_data);
+    free(ctx);
+}
+
+const modbus_backend_t _modbus_rtutcp_backend = {
+    _MODBUS_BACKEND_TYPE_RTUTCP,
+    _MODBUS_RTUTCP_HEADER_LENGTH,
+    _MODBUS_RTUTCP_CHECKSUM_LENGTH,
+    MODBUS_RTUTCP_MAX_ADU_LENGTH,
+    _modbus_set_slave,
+    _modbus_rtutcp_build_request_basis,
+    _modbus_rtutcp_build_response_basis,
+    _modbus_rtutcp_prepare_response_tid,
+    _modbus_rtutcp_send_msg_pre,
+    _modbus_rtutcp_send,
+    _modbus_rtutcp_receive,
+    _modbus_rtutcp_recv,
+    _modbus_rtutcp_check_integrity,
+    NULL,
+    _modbus_rtutcp_connect,
+    _modbus_rtutcp_close,
+    _modbus_rtutcp_flush,
+    _modbus_rtutcp_select,
+    _modbus_rtutcp_free
+};
+
+const modbus_backend_t _modbus_rtutcp_pi_backend = {
+    _MODBUS_BACKEND_TYPE_RTUTCP,
+    _MODBUS_RTUTCP_HEADER_LENGTH,
+    _MODBUS_RTUTCP_CHECKSUM_LENGTH,
+    MODBUS_RTUTCP_MAX_ADU_LENGTH,
+    _modbus_set_slave,
+    _modbus_rtutcp_build_request_basis,
+    _modbus_rtutcp_build_response_basis,
+    _modbus_rtutcp_prepare_response_tid,
+    _modbus_rtutcp_send_msg_pre,
+    _modbus_rtutcp_send,
+    _modbus_rtutcp_receive,
+    _modbus_rtutcp_recv,
+    _modbus_rtutcp_check_integrity,
+    NULL,
+    _modbus_rtutcp_pi_connect,
+    _modbus_rtutcp_close,
+    _modbus_rtutcp_flush,
+    _modbus_rtutcp_select,
+    _modbus_rtutcp_free
+};
+
+modbus_t* modbus_new_rtutcp(const char *ip, int port)
+{
+    modbus_t *ctx;
+    modbus_tcp_t *ctx_tcp;
+    size_t dest_size;
+    size_t ret_size;
+
+#if defined(OS_BSD)
+    /* MSG_NOSIGNAL is unsupported on *BSD so we install an ignore
+       handler for SIGPIPE. */
+    struct sigaction sa;
+
+    sa.sa_handler = SIG_IGN;
+    if (sigaction(SIGPIPE, &sa, NULL) < 0) {
+        /* The debug flag can't be set here... */
+        fprintf(stderr, "Could not install SIGPIPE handler.\n");
+        return NULL;
+    }
+#endif
+
+    ctx = (modbus_t *)malloc(sizeof(modbus_t));
+    if (ctx == NULL) {
+        return NULL;
+    }
+    _modbus_init_common(ctx);
+
+    ctx->backend = &_modbus_rtutcp_backend;
+
+    ctx->backend_data = (modbus_rtutcp_t *) malloc(sizeof(modbus_rtutcp_t));
+    if (ctx->backend_data == NULL) {
+        modbus_free(ctx);
+        errno = ENOMEM;
+        return NULL;
+    }
+    ctx_tcp = (modbus_tcp_t *)ctx->backend_data;
+
+    if (ip != NULL) {
+        dest_size = sizeof(char) * 16;
+        ret_size = strlcpy(ctx_tcp->ip, ip, dest_size);
+        if (ret_size == 0) {
+            fprintf(stderr, "The IP string is empty\n");
+            modbus_free(ctx);
+            errno = EINVAL;
+            return NULL;
+        }
+
+        if (ret_size >= dest_size) {
+            fprintf(stderr, "The IP string has been truncated\n");
+            modbus_free(ctx);
+            errno = EINVAL;
+            return NULL;
+        }
+    } else {
+        ctx_tcp->ip[0] = '0';
+    }
+    ctx_tcp->port = port;
+    ctx_tcp->t_id = 0;
+
+    return ctx;
+}
+
+
+modbus_t* modbus_new_rtutcp_pi(const char *node, const char *service)
+{
+    modbus_t *ctx;
+    modbus_tcp_pi_t *ctx_tcp_pi;
+    size_t dest_size;
+    size_t ret_size;
+
+    ctx = (modbus_t *)malloc(sizeof(modbus_t));
+    if (ctx == NULL) {
+        return NULL;
+    }
+    _modbus_init_common(ctx);
+
+    ctx->backend = &_modbus_rtutcp_pi_backend;
+
+    ctx->backend_data = (modbus_rtutcp_pi_t *) malloc(sizeof(modbus_rtutcp_pi_t));
+    if (ctx->backend_data == NULL) {
+        modbus_free(ctx);
+        errno = ENOMEM;
+        return NULL;
+    }
+    ctx_tcp_pi = (modbus_tcp_pi_t *)ctx->backend_data;
+
+    if (node == NULL) {
+        /* The node argument can be empty to indicate any hosts */
+        ctx_tcp_pi->node[0] = 0;
+    } else {
+        dest_size = sizeof(char) * _MODBUS_TCP_PI_NODE_LENGTH;
+        ret_size = strlcpy(ctx_tcp_pi->node, node, dest_size);
+        if (ret_size == 0) {
+            fprintf(stderr, "The node string is empty\n");
+            modbus_free(ctx);
+            errno = EINVAL;
+            return NULL;
+        }
+
+        if (ret_size >= dest_size) {
+            fprintf(stderr, "The node string has been truncated\n");
+            modbus_free(ctx);
+            errno = EINVAL;
+            return NULL;
+        }
+    }
+
+    if (service != NULL) {
+        dest_size = sizeof(char) * _MODBUS_TCP_PI_SERVICE_LENGTH;
+        ret_size = strlcpy(ctx_tcp_pi->service, service, dest_size);
+    } else {
+        /* Empty service is not allowed, error catched below. */
+        ret_size = 0;
+    }
+
+    if (ret_size == 0) {
+        fprintf(stderr, "The service string is empty\n");
+        modbus_free(ctx);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (ret_size >= dest_size) {
+        fprintf(stderr, "The service string has been truncated\n");
+        modbus_free(ctx);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    ctx_tcp_pi->t_id = 0;
+
+    return ctx;
+}

--- a/src/modbus-rtutcp.h
+++ b/src/modbus-rtutcp.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#ifndef MODBUS_RTUTCP_H
+#define MODBUS_RTUTCP_H
+
+#include "modbus.h"
+
+MODBUS_BEGIN_DECLS
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+/* Win32 with MinGW, supplement to <errno.h> */
+#include <winsock2.h>
+#define ECONNRESET   WSAECONNRESET
+#define ECONNREFUSED WSAECONNREFUSED
+#define ETIMEDOUT    WSAETIMEDOUT
+#define ENOPROTOOPT  WSAENOPROTOOPT
+#endif
+
+#define MODBUS_RTUTCP_DEFAULT_PORT   502
+
+/* Modbus_Application_Protocol_V1_1b.pdf Chapter 4 Section 1 Page 5
+ * RS232 / RS485 ADU = 253 bytes + slave (1 byte) + CRC (2 bytes) = 256 bytes
+ */
+#define MODBUS_RTUTCP_MAX_ADU_LENGTH  256
+
+MODBUS_API modbus_t* modbus_new_rtutcp(const char *ip_address, int port);
+MODBUS_API int modbus_rtutcp_listen(modbus_t *ctx, int nb_connection);
+MODBUS_API int modbus_rtutcp_accept(modbus_t *ctx, int *socket);
+
+MODBUS_API modbus_t* modbus_new_rtutcp_pi(const char *node, const char *service);
+MODBUS_API int modbus_rtutcp_pi_listen(modbus_t *ctx, int nb_connection);
+MODBUS_API int modbus_rtutcp_pi_accept(modbus_t *ctx, int *socket);
+
+MODBUS_END_DECLS
+
+#endif /* MODBUS_RTUTCP_H */

--- a/src/modbus-tcp-private.h
+++ b/src/modbus-tcp-private.h
@@ -41,4 +41,12 @@ typedef struct _modbus_tcp_pi {
     char service[_MODBUS_TCP_PI_SERVICE_LENGTH];
 } modbus_tcp_pi_t;
 
+ssize_t _modbus_tcp_send(modbus_t *ctx, const uint8_t *req, int req_length);
+int _modbus_tcp_receive(modbus_t *ctx, uint8_t *req);
+ssize_t _modbus_tcp_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length);
+int _modbus_tcp_connect(modbus_t *ctx);
+int _modbus_tcp_pi_connect(modbus_t *ctx);
+void _modbus_tcp_close(modbus_t *ctx);
+int _modbus_tcp_select(modbus_t *ctx, fd_set *rfds, struct timeval *tv, int length_to_read);
+
 #endif /* MODBUS_TCP_PRIVATE_H */

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -163,7 +163,7 @@ static int _modbus_tcp_send_msg_pre(uint8_t *req, int req_length)
     return req_length;
 }
 
-static ssize_t _modbus_tcp_send(modbus_t *ctx, const uint8_t *req, int req_length)
+ssize_t _modbus_tcp_send(modbus_t *ctx, const uint8_t *req, int req_length)
 {
     /* MSG_NOSIGNAL
        Requests not to send SIGPIPE on errors on stream oriented
@@ -172,11 +172,11 @@ static ssize_t _modbus_tcp_send(modbus_t *ctx, const uint8_t *req, int req_lengt
     return send(ctx->s, (const char *)req, req_length, MSG_NOSIGNAL);
 }
 
-static int _modbus_tcp_receive(modbus_t *ctx, uint8_t *req) {
+int _modbus_tcp_receive(modbus_t *ctx, uint8_t *req) {
     return _modbus_receive_msg(ctx, req, MSG_INDICATION);
 }
 
-static ssize_t _modbus_tcp_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length) {
+ssize_t _modbus_tcp_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length) {
     return recv(ctx->s, (char *)rsp, rsp_length, 0);
 }
 
@@ -300,7 +300,7 @@ static int _connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen,
 }
 
 /* Establishes a modbus TCP connection with a Modbus server. */
-static int _modbus_tcp_connect(modbus_t *ctx)
+int _modbus_tcp_connect(modbus_t *ctx)
 {
     int rc;
     /* Specialized version of sockaddr for Internet socket address (same size) */
@@ -352,7 +352,7 @@ static int _modbus_tcp_connect(modbus_t *ctx)
 }
 
 /* Establishes a modbus TCP PI connection with a Modbus server. */
-static int _modbus_tcp_pi_connect(modbus_t *ctx)
+int _modbus_tcp_pi_connect(modbus_t *ctx)
 {
     int rc;
     struct addrinfo *ai_list;
@@ -430,7 +430,7 @@ static int _modbus_tcp_pi_connect(modbus_t *ctx)
 }
 
 /* Closes the network connection and socket in TCP mode */
-static void _modbus_tcp_close(modbus_t *ctx)
+void _modbus_tcp_close(modbus_t *ctx)
 {
     if (ctx->s != -1) {
         shutdown(ctx->s, SHUT_RDWR);
@@ -715,7 +715,7 @@ int modbus_tcp_pi_accept(modbus_t *ctx, int *s)
     return ctx->s;
 }
 
-static int _modbus_tcp_select(modbus_t *ctx, fd_set *rset, struct timeval *tv, int length_to_read)
+int _modbus_tcp_select(modbus_t *ctx, fd_set *rset, struct timeval *tv, int length_to_read)
 {
     int s_rc;
     while ((s_rc = select(ctx->s+1, rset, NULL, NULL, tv)) == -1) {

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -996,7 +996,7 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
     }
 
     /* Suppress any responses when the request was a broadcast */
-    return (ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU &&
+    return ((ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU || ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTUTCP) &&
             slave == MODBUS_BROADCAST_ADDRESS) ? 0 : send_msg(ctx, rsp, rsp_length);
 }
 

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -287,6 +287,7 @@ MODBUS_API void modbus_set_float_cdab(float f, uint16_t *dest);
 
 #include "modbus-tcp.h"
 #include "modbus-rtu.h"
+#include "modbus-rtutcp.h"
 
 MODBUS_END_DECLS
 

--- a/tests/unit-test-server.c
+++ b/tests/unit-test-server.c
@@ -188,7 +188,7 @@ int main(int argc, char*argv[])
 
     printf("Quit the loop: %s\n", modbus_strerror(errno));
 
-    if (use_backend == TCP) {
+    if (use_backend == TCP || use_backend == TCP_PI) {
         if (s != -1) {
             close(s);
         }


### PR DESCRIPTION
Issue #260 only implemented the client part of 'RTU over TCP', I needed the server part.
Also the approach of #260 some how contaminates the TCP files with RTU content.

Please consider my approach, I implemented both the client and the server for both
contexts 'RTU over TCP' and 'RTU over TCP IP' and I extended the tests and documents accordingly.

There is only one diffenence in behavior comparing to #260, my implementation requires a slave
to be set as required for context RTU, while #260 ignores it as does context TCP.

I tested the code for linux (debian strech) and Windows Visual Studio 2010.
However the test code needs some adoptions to compile with Visual Studio 2010.