### PR TITLE
doc: small re-wordings, fix various small typos and style issues

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ Modbus specification, instead all bytes are sent as fast as possible and a
 response or an indication is considered complete when all expected characters
 have been received. This implementation offers very fast communication but you
 must take care to set a response timeout of slaves less than response timeout of
-master (ortherwise other slaves may ignore master requests when one of the slave
+master (otherwise other slaves may ignore master requests when one of the slaves
 is not responding).
 
 To create a Modbus RTU context, you should use [modbus_new_rtu](modbus_new_rtu.md).
@@ -107,7 +107,7 @@ communications over TCP IPv4 and IPv6 networks. It does not require a checksum
 calculation as lower layer takes care of the same.
 
 Contrary to the TCP IPv4 only backend, the TCP PI backend offers hostname
-resolution but it consumes about 1Kb of additional memory.
+resolution but it consumes about 1 kB of additional memory.
 
 Create a Modbus TCP PI context, you should use [modbus_new_tcp_pi](modbus_new_tcp_pi.md).
 

--- a/docs/modbus_free.md
+++ b/docs/modbus_free.md
@@ -12,7 +12,7 @@ void modbus_free(modbus_t *ctx);
 
 ## Description
 
-The *modbus_free()* function shall free an allocated modbus_t structure.
+The *modbus_free()* function shall free an allocated *modbus_t* structure.
 
 ## Return value
 

--- a/docs/modbus_get_byte_from_bits.md
+++ b/docs/modbus_get_byte_from_bits.md
@@ -14,7 +14,7 @@ uint8_t modbus_get_byte_from_bits(const uint8_t *src, int index, unsigned int nb
 
 The *modbus_get_byte_from_bits()* function shall extract a value from many
 bits. All `nb_bits` bits from `src` at position `index` will be read as a
-single value. To obtain a full byte, set nb_bits to 8.
+single value. To obtain a full byte, set `nb_bits` to 8.
 
 ## Return value
 

--- a/docs/modbus_get_header_length.md
+++ b/docs/modbus_get_header_length.md
@@ -14,7 +14,7 @@ int modbus_get_header_length(modbus_t *ctx);
 
 The *modbus_get_header_length()* function shall retrieve the current header
 length from the backend. This function is convenient to manipulate a message and
-so its limited to low-level operations.
+so it's limited to low-level operations.
 
 ## Return value
 

--- a/docs/modbus_mapping_free.md
+++ b/docs/modbus_mapping_free.md
@@ -12,8 +12,8 @@ void modbus_mapping_free(modbus_mapping_t *mb_mapping);
 
 ## Description
 
-The function shall free the four arrays of mb_mapping_t structure and finally
-the mb_mapping_t referenced by `mb_mapping`.
+The function shall free the four arrays of *modbus_mapping_t* structure and finally
+the *modbus_mapping_t* itself referenced by `mb_mapping`.
 
 ## Return value
 

--- a/docs/modbus_mapping_new.md
+++ b/docs/modbus_mapping_new.md
@@ -14,7 +14,7 @@ modbus_mapping_t* modbus_mapping_new(int nb_bits, int nb_input_bits, int nb_regi
 
 The *modbus_mapping_new()* function shall allocate four arrays to store bits,
 input bits, registers and inputs registers. The pointers are stored in
-modbus_mapping_t structure. All values of the arrays are initialized to zero.
+*modbus_mapping_t* structure. All values of the arrays are initialized to zero.
 
 This function is equivalent to a call of the
 [modbus_mapping_new_start_address](modbus_mapping_new_start_address.md) function

--- a/docs/modbus_mapping_new_start_address.md
+++ b/docs/modbus_mapping_new_start_address.md
@@ -18,12 +18,12 @@ modbus_mapping_t* modbus_mapping_new_start_address(
 
 The `modbus_mapping_new_start_address()` function shall allocate four arrays to
 store bits, input bits, registers and inputs registers. The pointers are stored
-in modbus_mapping_t structure. All values of the arrays are initialized to zero.
+in *modbus_mapping_t* structure. All values of the arrays are initialized to zero.
 
 The different starting addresses make it possible to place the mapping at any
-address in each address space. This way, you can give access to the clients at
+address in each address space. This way, you can give access to clients to
 values stored at high addresses without allocating memory from the address zero,
-for eg. to make available registers from 340 to 349, you can use:
+for example to make available registers from 340 to 349, you can use:
 
 ```c
 mb_mapping = modbus_mapping_new_start_address(0, 0, 0, 0, 340, 10, 0, 0);

--- a/docs/modbus_new_tcp.md
+++ b/docs/modbus_new_tcp.md
@@ -12,7 +12,7 @@ modbus_t *modbus_new_tcp(const char *ip, int port);
 
 ## Description
 
-The *modbus_new_tcp()* function shall allocate and initialize a modbus_t
+The *modbus_new_tcp()* function shall allocate and initialize a *modbus_t*
 structure to communicate with a Modbus TCP IPv4 server.
 
 The `ip` argument specifies the IP address of the server to which the client
@@ -20,8 +20,8 @@ wants to establish a connection. A NULL value can be used to listen any addresse
 server mode.
 
 The `port` argument is the TCP port to use. Set the port to
-`MODBUS_TCP_DEFAULT_PORT` to use the default one (502). It’s convenient to use a
-port number greater than or equal to 1024 because it’s not necessary to have
+`MODBUS_TCP_DEFAULT_PORT` to use the default one (502). It's convenient to use a
+port number greater than or equal to 1024 because it's not necessary to have
 administrator privileges.
 
 ## Return value

--- a/docs/modbus_new_tcp_pi.md
+++ b/docs/modbus_new_tcp_pi.md
@@ -12,7 +12,7 @@ modbus_new_tcp_pi - create a libmodbus context for TCP Protocol Independent
 
 ## Description
 
-The *modbus_new_tcp_pi()* function shall allocate and initialize a modbus_t
+The *modbus_new_tcp_pi()* function shall allocate and initialize a *modbus_t*
 structure to communicate with a Modbus TCP IPv4 or IPv6 server.
 
 The `node` argument specifies the host name or IP address of the host to connect
@@ -21,8 +21,8 @@ listen any addresses in server mode.
 
 The `service` argument is the service name/port number to connect to. To use the
 default Modbus port, you can provide an NULL value or the string "502". On many
-Unix systems, it’s convenient to use a port number greater than or equal to 1024
-because it’s not necessary to have administrator privileges.
+Unix systems, it's convenient to use a port number greater than or equal to 1024
+because it's not necessary to have administrator privileges.
 
 :octicons-tag-24: v3.1.8 handles NULL value for `service` (no *EINVAL* error).
 

--- a/docs/modbus_read_input_bits.md
+++ b/docs/modbus_read_input_bits.md
@@ -13,7 +13,7 @@ int modbus_read_input_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest);
 ## Description
 
 The *modbus_read_input_bits()* function shall read the content of the `nb` input
-bits to the address `addr` of the remote device.  The result of reading is stored
+bits to the address `addr` of the remote device. The result of reading is stored
 in `dest` array as unsigned bytes (8 bits) set to `TRUE` or `FALSE`.
 
 You must take care to allocate enough memory to store the results in `dest`

--- a/docs/modbus_receive.md
+++ b/docs/modbus_receive.md
@@ -13,7 +13,7 @@ int modbus_receive(modbus_t *'ctx', uint8_t *'req');
 ## Description
 
 The *modbus_receive()* function shall receive an indication request from the
-socket of the context `ctx`. This function is used by Modbus slave/server to
+socket of the context `ctx`. This function is used by a Modbus slave/server to
 receive and analyze indication request sent by the masters/clients.
 
 If you need to use another socket or file descriptor than the one defined in the

--- a/docs/modbus_reply.md
+++ b/docs/modbus_reply.md
@@ -21,7 +21,7 @@ modbus mapping `mb_mapping` according to the type of the manipulated data.
 
 If an error occurs, an exception response will be sent.
 
-This function is designed for Modbus server.
+This function is designed for Modbus servers.
 
 ## Return value
 

--- a/docs/modbus_rtu_get_rts.md
+++ b/docs/modbus_rtu_get_rts.md
@@ -23,8 +23,8 @@ This function can only be used with a context using a RTU backend.
 
 ## Return value
 
-The function shall return the current RTS mode if successful. Otherwise it shall
-return -1 and set errno.
+The function shall return the current RTS mode if successful. Otherwise it
+shall return -1 and set errno to one of the values defined below.
 
 ## Errors
 

--- a/docs/modbus_rtu_get_rts_delay.md
+++ b/docs/modbus_rtu_get_rts_delay.md
@@ -19,8 +19,8 @@ This function can only be used with a context using a RTU backend.
 
 ## Return value
 
-The `modbus_rtu_get_rts_delay()` function shall return the current RTS delay in
-microseconds if successful. Otherwise it shall return -1 and set errno.
+The function shall return the current RTS delay in microseconds if successful.
+Otherwise it shall return -1 and set errno to one of the values defined below.
 
 ## Errors
 

--- a/docs/modbus_rtu_get_serial_mode.md
+++ b/docs/modbus_rtu_get_serial_mode.md
@@ -15,13 +15,13 @@ int modbus_rtu_get_serial_mode(modbus_t *ctx);
 The *modbus_rtu_get_serial_mode()* function shall return the serial mode
 currently used by the libmodbus context:
 
-- **MODBUS_RTU_RS232**, the serial line is set for RS232 communication. RS-232
+- **MODBUS_RTU_RS232**, the serial line is set for RS-232 communication. RS-232
   (Recommended Standard 232) is the traditional name for a series of standards
   for serial binary single-ended data and control signals connecting between a
   DTE (Data Terminal Equipment) and a DCE (Data Circuit-terminating Equipment).
   It is commonly used in computer serial ports
 
-- **MODBUS_RTU_RS485**, the serial line is set for RS485 communication. EIA-485,
+- **MODBUS_RTU_RS485**, the serial line is set for RS-485 communication. EIA-485,
   also known as TIA/EIA-485 or RS-485, is a standard defining the electrical
   characteristics of drivers and receivers for use in balanced digital
   multipoint systems. This standard is widely used for communications in

--- a/docs/modbus_rtu_set_rts.md
+++ b/docs/modbus_rtu_set_rts.md
@@ -13,7 +13,7 @@ int modbus_rtu_set_rts(modbus_t *ctx, int mode)
 ## Description
 
 The *modbus_rtu_set_rts()* function shall set the Request To Send mode to
-communicate on a RS485 serial bus. By default, the mode is set to
+communicate on a RS-485 serial bus. By default, the mode is set to
 `MODBUS_RTU_RTS_NONE` and no signal is issued before writing data on the wire.
 
 To enable the RTS mode, the values `MODBUS_RTU_RTS_UP` or `MODBUS_RTU_RTS_DOWN`

--- a/docs/modbus_rtu_set_serial_mode.md
+++ b/docs/modbus_rtu_set_serial_mode.md
@@ -15,13 +15,13 @@ int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode);
 The *modbus_rtu_set_serial_mode()* function shall set the selected serial
 mode:
 
-- **MODBUS_RTU_RS232**, the serial line is set for RS232 communication. RS-232
+- **MODBUS_RTU_RS232**, the serial line is set for RS-232 communication. RS-232
   (Recommended Standard 232) is the traditional name for a series of standards
   for serial binary single-ended data and control signals connecting between a
   DTE (Data Terminal Equipment) and a DCE (Data Circuit-terminating Equipment).
   It is commonly used in computer serial ports.
 
-- **MODBUS_RTU_RS485**, the serial line is set for RS485 communication.
+- **MODBUS_RTU_RS485**, the serial line is set for RS-485 communication.
 EIA-485, also known as TIA/EIA-485 or RS-485, is a standard defining the
 electrical characteristics of drivers and receivers for use in balanced
 digital multipoint systems. This standard is widely used for communications

--- a/docs/modbus_set_error_recovery.md
+++ b/docs/modbus_set_error_recovery.md
@@ -38,7 +38,7 @@ expected one. The response timeout delay will be used to sleep.
 
 The modes are mask values and so they are complementary.
 
-It's not recommended to enable error recovery for slave/server.
+It's not recommended to enable error recovery for a Modbus slave/server.
 
 ## Return value
 

--- a/docs/modbus_strerror.md
+++ b/docs/modbus_strerror.md
@@ -13,7 +13,7 @@ const char *modbus_strerror(int errnum);
 ## Description
 
 The *modbus_strerror()* function shall return a pointer to an error message
-string corresponding to the error number specified by the `errnum` argument.  As
+string corresponding to the error number specified by the `errnum` argument. As
 libmodbus defines additional error numbers over and above those defined by the
 operating system, applications should use *modbus_strerror()* in preference to
 the standard *strerror()* function.

--- a/docs/modbus_tcp_listen.md
+++ b/docs/modbus_tcp_listen.md
@@ -14,7 +14,7 @@ int modbus_tcp_listen(modbus_t *ctx, int nb_connection);
 ## Description
 
 The *modbus_tcp_listen()* function shall create a socket and listen to maximum
-`nb_connection` incoming connections on the specified IP address.  The context
+`nb_connection` incoming connections on the specified IP address. The context
 `ctx` must be allocated and initialized with [modbus_new_tcp](modbus_new_tcp.md) before to
 set the IP address to listen, if IP address is set to NULL or '0.0.0.0', any addresses will be
 listen.

--- a/docs/modbus_tcp_pi_listen.md
+++ b/docs/modbus_tcp_pi_listen.md
@@ -13,7 +13,7 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection);
 ## Description
 
 The *modbus_tcp_pi_listen()* function shall create a socket and listen to
-maximum `nb_connection` incoming connections on the specified nodes.  The
+maximum `nb_connection` incoming connections on the specified nodes. The
 context *ctx* must be allocated and initialized with [modbus_new_tcp_pi](modbus_new_tcp_pi.md)
 before to set the node to listen, if node is set to NULL or '0.0.0.0', any addresses will be
 listen.


### PR DESCRIPTION
For example:
- use *bold* text when refering to functions
- use _italic_ when refering to function parameters or typedef names
- use two empty lines between sections

Signed-off-by: Michael Heimpold <mhei@heimpold.de>