### PR TITLE
fix segmentation fault

### DIFF
--- a/src/modbus-ascii.c
+++ b/src/modbus-ascii.c
@@ -231,6 +231,7 @@ static ssize_t _modbus_ascii_send(modbus_t *ctx, const uint8_t *req, int req_len
 
 static void _modbus_ascii_free(modbus_t *ctx) {
     _modbus_serial_free(ctx->backend_data);
+    free(ctx->backend_data);
     free(ctx);
 }
 

--- a/src/modbus-serial.c
+++ b/src/modbus-serial.c
@@ -1005,7 +1005,6 @@ void _modbus_serial_free(modbus_serial_t *ctx_serial)
     if (ctx_serial) {
         free(ctx_serial->device);
     }
-    free(ctx_serial);
 }
 
 #if HAVE_DECL_TIOCM_RTS


### PR DESCRIPTION
Hi, guys

when checking the ASCII mode source, i found modbus_free fucntion made a segmentation fault. 

In detail the modbus_free function calls the _modbus_ascii_free function and it call _modbus_serial_free function. and there is a double free logic so i fixed that. 

Thanks