### PR TITLE
Add MODBUS_RTU_NO_SLAVE_SELECTION to allow user to get requests from …

### DIFF
--- a/doc/modbus_set_slave.txt
+++ b/doc/modbus_set_slave.txt
@@ -23,6 +23,8 @@ The behavior depends of network and the role of the device:
 Define the slave ID of the remote device to talk in master mode or set the
 internal slave ID in slave mode. According to the protocol, a Modbus device must
 only accept message holding its slave number or the special broadcast number.
+The special value `MODBUS_RTU_NO_SLAVE_SELECTION` (0xFF) can be used in RTU mode 
+to return requests from all slave id.
 
 *TCP*::
 The slave number is only required in TCP if the message must reach a device on a

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -94,6 +94,10 @@ static int _modbus_set_slave(modbus_t *ctx, int slave)
     /* Broadcast address is 0 (MODBUS_BROADCAST_ADDRESS) */
     if (slave >= 0 && slave <= 247) {
         ctx->slave = slave;
+    } else if(slave == MODBUS_RTU_NO_SLAVE_SELECTION) {
+        /* The special value MODBUS_RTU_NO_SLAVE_SELECTION (0xFF) can be used in RTU
+         * rmode to return all the RTU message from all slave id in server mode */
+        ctx->slave = slave;
     } else {
         errno = EINVAL;
         return -1;
@@ -365,7 +369,7 @@ static int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
 
     /* Filter on the Modbus unit identifier (slave) in RTU mode to avoid useless
      * CRC computing. */
-    if (slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS) {
+    if ((ctx->slave != MODBUS_RTU_NO_SLAVE_SELECTION && slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS)) {
         if (ctx->debug) {
             printf("Request for slave %d ignored (not %d)\n", slave, ctx->slave);
         }

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -22,6 +22,8 @@ MODBUS_API modbus_t* modbus_new_rtu(const char *device, int baud, char parity,
 #define MODBUS_RTU_RS232 0
 #define MODBUS_RTU_RS485 1
 
+#define MODBUS_RTU_NO_SLAVE_SELECTION 0xFF
+
 MODBUS_API int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode);
 MODBUS_API int modbus_rtu_get_serial_mode(modbus_t *ctx);
 


### PR DESCRIPTION
…all the slave id.


This new settings allow the user to create a Modbus "virtual device" which can answers to different slave id request. It a kind a gateway functionality:

                                                                         |<-->Modbus map A (slave x)
Master RTU <-----[RTU]----->"Virtual device"
                                                                         |<-->Modbus map B (slave y)
