### PR TITLE
Add Android build scripts, #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,9 @@ tests/unit-test-server
 tests/version
 tests/stamp-h2
 doc/*.html
+jni/config.h
+jni/modbus-version.h
 doc/*.3
 doc/*.7
+/libs
+/obj

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,0 +1,17 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := modbus
+
+LOCAL_SRC_FILES := \
+	../src/modbus-data.c \
+	../src/modbus-rtu.c \
+	../src/modbus-tcp.c \
+	../src/modbus.c \
+
+
+# Prepare config.h and modbus-version.h
+$(shell python $(LOCAL_PATH)/configure.py)
+
+include $(BUILD_SHARED_LIBRARY)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,0 +1,3 @@
+APP_ABI := all
+APP_OPTIM := release
+NDK_TOOLCHAIN_VERSION := clang

--- a/jni/config.h.in
+++ b/jni/config.h.in
@@ -1,0 +1,261 @@
+/* config.h for Android */
+
+/* Define to 1 if you have the `accept4' function. */
+/* #undef HAVE_ACCEPT4 */
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#define HAVE_ARPA_INET_H 1
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+#define HAVE_BYTESWAP_H 1
+
+/* Define to 1 if you have the declaration of `TIOCM_RTS', and to 0 if you
+   don't. */
+#define HAVE_DECL_TIOCM_RTS 1
+
+/* Define to 1 if you have the declaration of `TIOCSRS485', and to 0 if you
+   don't. */
+#define HAVE_DECL_TIOCSRS485 0
+
+/* Define to 1 if you have the declaration of `__CYGWIN__', and to 0 if you
+   don't. */
+#define HAVE_DECL___CYGWIN__ 0
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <errno.h> header file. */
+#define HAVE_ERRNO_H 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the `fork' function. */
+#define HAVE_FORK 1
+
+/* Define to 1 if you have the `getaddrinfo' function. */
+#define HAVE_GETADDRINFO 1
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#define HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the `inet_ntoa' function. */
+#define HAVE_INET_NTOA 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if you have the <linux/serial.h> header file. */
+#define HAVE_LINUX_SERIAL_H 1
+
+/* Define to 1 if your system has a GNU libc compatible `malloc' function, and
+   to 0 otherwise. */
+#define HAVE_MALLOC 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `memset' function. */
+#define HAVE_MEMSET 1
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#define HAVE_NETDB_H 1
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#define HAVE_NETINET_IN_H 1
+
+/* Define to 1 if you have the <netinet/tcp.h> header file. */
+#define HAVE_NETINET_TCP_H 1
+
+/* Define to 1 if you have the `select' function. */
+#define HAVE_SELECT 1
+
+/* Define to 1 if you have the `socket' function. */
+#define HAVE_SOCKET 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strerror' function. */
+#define HAVE_STRERROR 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strlcpy' function. */
+/* #undef HAVE_STRLCPY */
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#define HAVE_SYS_IOCTL_H 1
+
+/* Define to 1 if you have the <sys/params.h> header file. */
+/* #undef HAVE_SYS_PARAMS_H */
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#define HAVE_SYS_SOCKET_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <termios.h> header file. */
+#define HAVE_TERMIOS_H 1
+
+/* Define to 1 if you have the <time.h> header file. */
+#define HAVE_TIME_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `vfork' function. */
+#define HAVE_VFORK 1
+
+/* Define to 1 if you have the <vfork.h> header file. */
+/* #undef HAVE_VFORK_H */
+
+/* Define to 1 if you have the <winsock2.h> header file. */
+/* #undef HAVE_WINSOCK2_H */
+
+/* Define to 1 if `fork' works. */
+#define HAVE_WORKING_FORK 1
+
+/* Define to 1 if `vfork' works. */
+#define HAVE_WORKING_VFORK 1
+
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "libmodbus"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "https://github.com/stephane/libmodbus/issues"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libmodbus"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libmodbus @LIBMODBUS_VERSION@"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libmodbus"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "http://libmodbus.org/"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@LIBMODBUS_VERSION@"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
+/* Version number of package */
+#define VERSION "@LIBMODBUS_VERSION@"
+
+/* _ */
+#define WINVER 0x0501
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */
+
+/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT32_T */
+
+/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT8_T */
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define to the type of a signed integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int64_t */
+
+/* Define to rpl_malloc if the replacement function should be used. */
+/* #undef malloc */
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef pid_t */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef ssize_t */
+
+/* Define to the type of an unsigned integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint16_t */
+
+/* Define to the type of an unsigned integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint32_t */
+
+/* Define to the type of an unsigned integer type of width exactly 8 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint8_t */
+
+/* Define as `fork' if `vfork' does not work. */
+/* #undef vfork */

--- a/jni/configure.py
+++ b/jni/configure.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import re
+
+version = {}
+version['libmodbus_version_major'] = 0
+version['libmodbus_version_minor'] = 0
+version['libmodbus_version_micro'] = 0
+
+pattern = re.compile('m4_define\(\[(libmodbus_version_m[a-z]+)\], \[([0-9]+)\]\)');
+
+## Read the version numbers from ../configure.ac
+with open('configure.ac', 'r') as input:
+  for line in input:
+    match = pattern.match(line)
+    if match:
+      version[match.group(1)] = match.group(2)
+
+## Prepare the regex-patterns so we don't have to do that multiple times
+version_pattern = re.compile('@LIBMODBUS_VERSION@')
+version_major_pattern = re.compile('@LIBMODBUS_VERSION_MAJOR@')
+version_minor_pattern = re.compile('@LIBMODBUS_VERSION_MINOR@')
+version_micro_pattern = re.compile('@LIBMODBUS_VERSION_MICRO@')
+
+## Read jni/config.h.in and write jni/config.h
+infile =  open('jni/config.h.in', 'r')
+content = infile.read()
+infile.close()
+
+outfile = open('jni/config.h', 'w')
+
+content = version_pattern.sub(version['libmodbus_version_major'] + '.' + version['libmodbus_version_minor'] + '.' + version['libmodbus_version_micro'], content)
+
+outfile.write(content)
+outfile.close()
+
+## Read src/modbus-version.h.in and write jni/modbus-version.h
+infile =  open('src/modbus-version.h.in', 'r')
+content = infile.read()
+infile.close()
+
+outfile = open('jni/modbus-version.h', 'w')
+
+content = version_pattern.sub(version['libmodbus_version_major'] + '.' + version['libmodbus_version_minor'] + '.' + version['libmodbus_version_micro'], content)
+content = version_major_pattern.sub(version['libmodbus_version_major'], content)
+content = version_minor_pattern.sub(version['libmodbus_version_minor'], content)
+content = version_micro_pattern.sub(version['libmodbus_version_micro'], content)
+
+outfile.write(content)
+
+outfile.close()


### PR DESCRIPTION
Hi, this is basically a redo of #291. It's been clarified with all related parties that we I am safe to submit this now.

Dynamically linked android libraries can be easily created by running "ndk-build" in the libmodbus-directory.

Includes a python-script to automatically generate config.h and modbus-version.h before doing the actual compilation.