### PR TITLE
Topic/adding function read device identification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ tests/bandwidth-server-many-up
 tests/bandwidth-server-one
 tests/random-test-client
 tests/random-test-server
+tests/read-device-identification-client
 tests/unit-test-client
 tests/unit-test.h
 tests/unit-test-server

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -58,18 +58,21 @@ MODBUS_BEGIN_DECLS
 #endif
 
 /* Modbus function codes */
-#define MODBUS_FC_READ_COILS                0x01
-#define MODBUS_FC_READ_DISCRETE_INPUTS      0x02
-#define MODBUS_FC_READ_HOLDING_REGISTERS    0x03
-#define MODBUS_FC_READ_INPUT_REGISTERS      0x04
-#define MODBUS_FC_WRITE_SINGLE_COIL         0x05
-#define MODBUS_FC_WRITE_SINGLE_REGISTER     0x06
-#define MODBUS_FC_READ_EXCEPTION_STATUS     0x07
-#define MODBUS_FC_WRITE_MULTIPLE_COILS      0x0F
-#define MODBUS_FC_WRITE_MULTIPLE_REGISTERS  0x10
-#define MODBUS_FC_REPORT_SLAVE_ID           0x11
-#define MODBUS_FC_MASK_WRITE_REGISTER       0x16
-#define MODBUS_FC_WRITE_AND_READ_REGISTERS  0x17
+#define MODBUS_FC_READ_COILS                     0x01
+#define MODBUS_FC_READ_DISCRETE_INPUTS           0x02
+#define MODBUS_FC_READ_HOLDING_REGISTERS         0x03
+#define MODBUS_FC_READ_INPUT_REGISTERS           0x04
+#define MODBUS_FC_WRITE_SINGLE_COIL              0x05
+#define MODBUS_FC_WRITE_SINGLE_REGISTER          0x06
+#define MODBUS_FC_READ_EXCEPTION_STATUS          0x07
+#define MODBUS_FC_WRITE_MULTIPLE_COILS           0x0F
+#define MODBUS_FC_WRITE_MULTIPLE_REGISTERS       0x10
+#define MODBUS_FC_REPORT_SLAVE_ID                0x11
+#define MODBUS_FC_MASK_WRITE_REGISTER            0x16
+#define MODBUS_FC_WRITE_AND_READ_REGISTERS       0x17
+#define MODBUS_FC_MODBUS_ENCAPSULATED_INTERFACE  0x2B
+
+#define MODBUS_MEI_READ_DEVICE_IDENTIFICATION    0x0E
 
 #define MODBUS_BROADCAST_ADDRESS    0
 
@@ -237,6 +240,27 @@ MODBUS_API int modbus_reply(modbus_t *ctx, const uint8_t *req,
                             int req_length, modbus_mapping_t *mb_mapping);
 MODBUS_API int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,
                                       unsigned int exception_code);
+/* Requests the MODBUS function READ DEVICE IDENTIFICATION (Function code 0x2B /
+ * MEI type 0x0E) of the remote device and put the response into the given array dest.
+ * The return value tells how many bytes have been available and can be greater
+ * than the array size dest_size, if the array is too small. But only at most
+ * dest_size bytes are written to dest. The return value may be -1 to indicate
+ * an error. In this case errno is set, appropriately.
+ * When being executed without error, the contents of dest conforms to the
+ * response as defined in the the MODBUS Specification
+ * (http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b.pdf)
+ * in Chapter "6.21 Read Device Identification".
+ * A dest buffer of size 260 bytes is sufficent.
+ * Use object_id = 0 to read the first of possible multiple data blocks.
+ * Each following data block can be requested by a new call, with the object_id
+ * set to that given in the previous response. There is no need by the specification
+ * to request further data blocks.
+ */
+MODBUS_API int modbus_read_device_identification(modbus_t *ctx,
+                                                 uint8_t read_device_id_code,
+                                                 uint8_t object_id, int dest_size,
+                                                 uint8_t *dest);
+
 
 /**
  * UTILS FUNCTIONS

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,6 +6,7 @@ noinst_PROGRAMS = \
 	bandwidth-client \
 	random-test-server \
 	random-test-client \
+	read-device-identification-client \
 	unit-test-server \
 	unit-test-client \
 	version
@@ -27,6 +28,9 @@ random_test_server_LDADD = $(common_ldflags)
 
 random_test_client_SOURCES = random-test-client.c
 random_test_client_LDADD = $(common_ldflags)
+
+read_device_identification_client_SOURCES = read-device-identification-client.c
+read_device_identification_client_LDADD = $(common_ldflags)
 
 unit_test_server_SOURCES = unit-test-server.c unit-test.h
 unit_test_server_LDADD = $(common_ldflags)

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,3 +25,11 @@ behavior.
  the server and the client. `bandwidth-server-one` can only handles one
  connection at once with a client whereas `bandwidth-server-many-up` opens a
  connection for each new clients (with a limit).
+
+- `read-device-identification-client` requests the Modbus Encapsulated Interface
+ (MEI) function READ DEVICE IDENTIFICATION from a Modbus slave device. The slave
+ id must be given on the command line. The Basic Device Identification
+ (read_device_id_code = 1) is requested and comprises the ASCII Strings VendorName,
+ ProductCode and MajorMinorRevision (see official Modbus Application Protocol
+ Specification V1.1b, Chapter 6.21,
+ http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b.pdf).

--- a/tests/read-device-identification-client.c
+++ b/tests/read-device-identification-client.c
@@ -1,0 +1,121 @@
+/* Client for function modbus_read_device_identification
+   Author: Tim Knecht <t.knecht@eckelmann.de>
+*/
+#include <errno.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <modbus.h>
+
+/* Configuration of modbus device SECOP SLV 105N4627 on RS232 with RS485
+   converter.
+   https://www.secop.com/fileadmin/user_upload/technical-literature/operating-instructions/slv_controller_105n46xx-series_operating_instructions_02-2013_dess300a202.pdf
+*/
+#define   DEV_MODBUS      "/dev/COM4"
+#define   MODBUS_SPEED    19200
+#define   MODBUS_PARITY   'E'
+#define   MODBUS_BYTES    8
+#define   MODBUS_STOPBIT  1
+#define   MODBUS_RTU_MODE MODBUS_RTU_RS232
+
+/* Expected output (Slave ID 42): <<OUTPUT_END
+read-device-identification-client
+Trying slave_id 42...
+Opening /dev/COM4 at 19200 bauds (E, 8, 1)
+[2A][2B][0E][01][00][54][71]
+Waiting for a confirmation...
+<2A><2B><0E><01><01><00><00><03><00><05><53><45><43><4F><50><01><08><31><30><35><4E><34><36><32><37><02><05><30><31><2E><31><30><E4><78>
+read_device_id returned: 31
+function code: 2b, MEI type: e, Read Device ID code: 1, conformity level: 1
+more_follows: 0, next_object_id: 0, number of objects: 3
+1. Object ID: 0, length: 5, "SECOP"
+2. Object ID: 1, length: 8, "105N4627"
+3. Object ID: 2, length: 5, "01.10"
+OUTPUT_END
+*/
+int main(int argc, const char *argv[])
+{
+    if (argc != 2) {
+        printf("Usage: test-libmodbus <slave_id>\n");
+        return 1;
+    }
+    int slave_id = atoi(argv[1]);
+
+    printf("read-device-identification-client\nTrying slave_id %d...\n", slave_id);
+
+    modbus_t *ctx = modbus_new_rtu(DEV_MODBUS, MODBUS_SPEED, MODBUS_PARITY,
+                                             MODBUS_BYTES, MODBUS_STOPBIT);
+    if (ctx == NULL)
+    {
+        printf("Unable to create the libmodbus context!\n");
+        return 1;
+    }
+
+    modbus_set_debug(ctx, TRUE);
+
+    if (modbus_connect(ctx) == -1)
+    {
+        printf("Connection failed: %s!\n", modbus_strerror(errno));
+        modbus_free(ctx);
+        return 2;
+    }
+
+    if (modbus_set_slave(ctx, slave_id) == -1)
+    {
+        printf("Error setting slave id: %s!\n", modbus_strerror(errno));
+        modbus_close(ctx);
+        modbus_free(ctx);
+        return 3;
+    }
+
+    if (modbus_rtu_set_serial_mode(ctx, MODBUS_RTU_MODE) == -1)
+    {
+        printf("Error setting serial mode: %s!\n", modbus_strerror(errno));
+        modbus_close(ctx);
+        modbus_free(ctx);
+        return 4;
+    }
+
+    uint8_t response[260];
+    const int response_size = sizeof(response);
+    const int read_device_id_code = 1; /* Basic Device Identification (VendorName, ProductCode and MajorMinorRevision)*/
+    int next_object_id = 0;
+    int more_follows = 0xff;
+    int rc;
+
+    while (more_follows == 0xff) {
+        rc = modbus_read_device_identification(ctx, read_device_id_code, next_object_id, response_size, response);
+        if (rc == -1)
+        {
+            printf("Read device identification failed: %s!\n", modbus_strerror(errno));
+
+            modbus_close(ctx);
+            modbus_free(ctx);
+            return 5;
+        }
+        printf("read_device_id returned: %d\n", rc);
+        more_follows = response[4];
+        next_object_id = response[5];
+        int object_cnt = response[6];
+        printf("function code: %x, MEI type: %x, Read Device ID code: %d, conformity level: %x\n",
+                (int)response[0], (int)response[1], (int)response[2], (int)response[3]);
+        printf("more_follows: %x, next_object_id: %x, number of objects: %d\n",
+                more_follows, next_object_id, object_cnt);
+        int offset = 7;
+        for (int i = 0; i < object_cnt; i++) {
+            int object_length = response[offset + 1];
+            printf("%d. Object ID: %x, length: %d, \"%.*s\"\n", i + 1, (int)response[offset], object_length,
+                 object_length, response + offset + 2);
+            offset += object_length + 2;
+        }
+        /* Some devices needs some time before sending new request. */
+        sleep(1);
+    }
+
+    modbus_close(ctx);
+    modbus_free(ctx);
+
+    return 0;
+}


### PR DESCRIPTION
Bonjour et hello!

Over four years ago I send you a patch for libmodbus, that implements the Modbus protocol function READ DEVICE IDENTIFICATION. As an answer, you requested a more DRY Version (see libmodbus mailing list https://groups.google.com/forum/#!msg/libmodbus/eH1NcZ7YVdk/PXFJlvf26PwJ ).
Unfortunately, at that time, it was not possible for me to rework the patch.
Meanwhile, there is a greater need in my department to mainline the changes, we made to open source projects, that we use in our devices. Because of that, the focus has come back to libmodbus.

So, here is my more DRY and improved version of the patch from those days.
It is based on the HEAD of the current master branch of libmodbus from your github account
It consists of two commits:
- one adding the function modbus_read_device_identification(), and
- one providing a test tool.

The function has been used in our embedded devices with the non-DRY version for three
years, now. There never seemed to be a problem, as far as I know.
But it only has been used for serial Modbus RTU.

Even the new patch has only been tested with Modbus RTU, using Linux. It should be able to handle
Modbus TCP correctly, as well, thanks to the improvements I made.

Modbus devices that implements the Modbus protocol specification correctly, but don't
support the READ DEVICE IDENTIFICATION function send an "illegal function" exception.
This case has been tested with one Modbus device.
