### PR TITLE
RFC: Use more enums

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,7 +141,8 @@ my_CFLAGS="-Wall \
 -Wnested-externs -Wpointer-arith \
 -Wpointer-arith -Wsign-compare -Wchar-subscripts \
 -Wstrict-prototypes -Wshadow \
--Wformat-security"
+-Wformat-security \
+-Werror=switch-enum"
 AC_SUBST([my_CFLAGS])
 
 # Build options

--- a/doc/modbus_rtu_set_serial_mode.txt
+++ b/doc/modbus_rtu_set_serial_mode.txt
@@ -9,7 +9,7 @@ modbus_rtu_set_serial_mode - set the serial mode
 
 SYNOPSIS
 --------
-*int modbus_rtu_set_serial_mode(modbus_t *'ctx', int 'mode');*
+*int modbus_rtu_set_serial_mode(modbus_t *'ctx', modbus_rtu_mode 'mode');*
 
 
 DESCRIPTION

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -61,7 +61,7 @@ typedef struct _modbus_rtu {
     struct termios old_tios;
 #endif
 #if HAVE_DECL_TIOCSRS485
-    int serial_mode;
+    modbus_rtu_mode serial_mode;
 #endif
 #if HAVE_DECL_TIOCM_RTS
     int rts;

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -910,7 +910,8 @@ int modbus_rtu_set_serial_mode(modbus_t *ctx, modbus_rtu_mode mode)
         modbus_rtu_t *ctx_rtu = ctx->backend_data;
         struct serial_rs485 rs485conf;
 
-        if (mode == MODBUS_RTU_RS485) {
+        switch (mode) {
+        case MODBUS_RTU_RS485:
             // Get
             if (ioctl(ctx->s, TIOCGRS485, &rs485conf) < 0) {
                 return -1;
@@ -923,7 +924,7 @@ int modbus_rtu_set_serial_mode(modbus_t *ctx, modbus_rtu_mode mode)
 
             ctx_rtu->serial_mode = MODBUS_RTU_RS485;
             return 0;
-        } else if (mode == MODBUS_RTU_RS232) {
+        case MODBUS_RTU_RS232:
             /* Turn off RS485 mode only if required */
             if (ctx_rtu->serial_mode == MODBUS_RTU_RS485) {
                 /* The ioctl call is avoided because it can fail on some RS232 ports */

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -898,7 +898,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
     return 0;
 }
 
-int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode)
+int modbus_rtu_set_serial_mode(modbus_t *ctx, modbus_rtu_mode mode)
 {
     if (ctx == NULL) {
         errno = EINVAL;

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -19,10 +19,12 @@ MODBUS_BEGIN_DECLS
 MODBUS_API modbus_t* modbus_new_rtu(const char *device, int baud, char parity,
                                     int data_bit, int stop_bit);
 
-#define MODBUS_RTU_RS232 0
-#define MODBUS_RTU_RS485 1
+typedef enum {
+    MODBUS_RTU_RS232 = 0,
+    MODBUS_RTU_RS485 = 1
+} modbus_rtu_mode;
 
-MODBUS_API int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode);
+MODBUS_API int modbus_rtu_set_serial_mode(modbus_t *ctx, modbus_rtu_mode mode);
 MODBUS_API int modbus_rtu_get_serial_mode(modbus_t *ctx);
 
 #define MODBUS_RTU_RTS_NONE   0

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -455,7 +455,7 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
                 }
                 step = _STEP_DATA;
                 break;
-            default:
+            case _STEP_DATA:
                 break;
             }
         }


### PR DESCRIPTION
Convert `modbus_rtu_mode` to a enum instead of two `#define`. This then extends the idea by enforcing compiler checking that these values are more correctly used.

Questions:
* Return Types?
```MODBUS_API int modbus_rtu_get_serial_mode(modbus_t *ctx);```
vs
```MODBUS_API modbus_rtu_mode modbus_rtu_get_serial_mode(modbus_t *ctx);```
As the return value is both `modbus_rtu_mode` and `-1` (for error) should it be typed to `modbus_rtu_mode` or `int`. Both are valid answers in `C` but I believe `modbus_rtu_mode` would lead to incorrect assumptions. Would a `union` be a more clear response?

* Is the idea sounds?
If so I believe that there is more examples that would work well as an enum. Example
```c
#define MODBUS_RTU_RTS_NONE   0
#define MODBUS_RTU_RTS_UP     1
#define MODBUS_RTU_RTS_DOWN   2
```
Does it make the API better? Will it cause API issues in the feature to add/remove values?

* Enum naming?
Should the name include `_t`?
`modbus.h: modbus_error_recovery_mode`
`modbus-private.h: modbus_backend_type_t`
