### PR TITLE
SPDX: change LGPL-2.1+ to LGPL-2.1-or-later

### DIFF
--- a/src/modbus-data.c
+++ b/src/modbus-data.c
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2010-2014 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include <stdlib.h>

--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2010-2012 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #ifndef MODBUS_PRIVATE_H

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #ifndef MODBUS_RTU_PRIVATE_H

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include <stdio.h>

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #ifndef MODBUS_RTU_H

--- a/src/modbus-tcp-private.h
+++ b/src/modbus-tcp-private.h
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #ifndef MODBUS_TCP_PRIVATE_H

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2001-2013 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #if defined(_WIN32)

--- a/src/modbus-tcp.h
+++ b/src/modbus-tcp.h
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2001-2010 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #ifndef MODBUS_TCP_H

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  *
  * This library implements the Modbus protocol.
  * http://libmodbus.org/

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2001-2013 Stéphane Raimbault <stephane.raimbault@gmail.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #ifndef MODBUS_H


### PR DESCRIPTION
Since SPDX release 3.0 LGPL-2.1+ became LGPL-2.1-or-later. Hence
replace the deprecated identifiers.