### PR TITLE
Allow handling any slave

### DIFF
--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -92,7 +92,7 @@ static const uint8_t table_crc_lo[] = {
 static int _modbus_set_slave(modbus_t *ctx, int slave)
 {
     /* Broadcast address is 0 (MODBUS_BROADCAST_ADDRESS) */
-    if (slave >= 0 && slave <= 247) {
+    if ((slave >= 0 && slave <= 247) || slave == MODBUS_ANY_SLAVE_ADDRESS) {
         ctx->slave = slave;
     } else {
         errno = EINVAL;
@@ -365,7 +365,7 @@ static int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
 
     /* Filter on the Modbus unit identifier (slave) in RTU mode to avoid useless
      * CRC computing. */
-    if (slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS) {
+    if (slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS && ctx->slave != MODBUS_ANY_SLAVE_ADDRESS) {
         if (ctx->debug) {
             printf("Request for slave %d ignored (not %d)\n", slave, ctx->slave);
         }

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -73,6 +73,9 @@ MODBUS_BEGIN_DECLS
 
 #define MODBUS_BROADCAST_ADDRESS    0
 
+/* This is to allow request indications from any slave */
+#define MODBUS_ANY_SLAVE_ADDRESS    0x100
+
 /* Modbus_Application_Protocol_V1_1b.pdf (chapter 6 section 1 page 12)
  * Quantity of Coils to read (2 bytes): 1 to 2000 (0x7D0)
  * (chapter 6 section 11 page 29)


### PR DESCRIPTION
I am writing a modbus slave simulator and need to have it be able to handle
any slave address that comes in, not just a single slave address

Signed-off-by: Jon Ringle <jringle@gridpoint.com>