### PR TITLE
Interframe delay in RTU ("t3.5")

### DIFF
--- a/doc/modbus_rtu_get_interframe_delay.txt
+++ b/doc/modbus_rtu_get_interframe_delay.txt
@@ -1,0 +1,47 @@
+modbus_rtu_get_interframe_delay(3)
+===========================
+
+
+NAME
+----
+modbus_rtu_get_interframe_delay - get the current value of silent interval between MODBUS frames in RTU
+
+
+SYNOPSIS
+--------
+*int modbus_rtu_get_interframe_delay(modbus_t *'ctx');*
+
+
+DESCRIPTION
+-----------
+
+The _modbus_rtu_get_interframe_delay()_ function shall get the current
+MODBUS interframe delay period of the libmodbus context 'ctx'.
+
+This function can only be used with a context using a RTU backend.
+
+
+RETURN VALUE
+------------
+The _modbus_rtu_get_interframe_delay()_ function shall return the current
+interframe delay in microseconds if successful.  Otherwise it shall return
+-1 and set errno.
+
+
+ERRORS
+------
+*EINVAL*::
+The libmodbus backend is not RTU.
+
+
+SEE ALSO
+--------
+linkmb:modbus_rtu_set_interframe_delay[3]
+
+
+AUTHORS
+-------
+oldgreen <oldoldgreen@gmail.com>
+
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/doc/modbus_rtu_set_interframe_delay.txt
+++ b/doc/modbus_rtu_set_interframe_delay.txt
@@ -1,0 +1,53 @@
+modbus_rtu_set_interframe_delay(3)
+===========================
+
+
+NAME
+----
+modbus_rtu_set_interframe_delay - set silent interval between MODBUS frames in RTU
+
+
+SYNOPSIS
+--------
+*int modbus_rtu_set_interframe_delay(modbus_t *'ctx', int 'us');*
+
+
+DESCRIPTION
+-----------
+
+The _modbus_rtu_set_interframe_delay()_ function shall set the silent
+interval between message frames (known as t3.5 in MODBUS RTU documentation)
+of the libmodbus context 'ctx'.
+
+The value of delay may be in the range 0 <= us < 1000000 (in microseconds)
+or it may be a special value MODBUS_RTU_INTERFRAME_AUTO (which is the
+default), in which case the value is set to 3.5 character times for baud
+rates up to 19200 (including) and to a fixed value of 1750 us otherwise.
+
+This function can only be used with a context using a RTU backend.
+
+
+RETURN VALUE
+------------
+The _modbus_rtu_set_interframe_delay()_ function shall return 0 if successful.
+Otherwise it shall return -1 and set errno.
+
+
+ERRORS
+------
+*EINVAL*::
+The libmodbus backend is not RTU or a delay of unsupported value was
+specified.
+
+
+SEE ALSO
+--------
+linkmb:modbus_rtu_get_interframe_delay[3]
+
+
+AUTHORS
+-------
+oldgreen <oldoldgreen@gmail.com>
+
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -7,6 +7,8 @@
 #ifndef MODBUS_RTU_PRIVATE_H
 #define MODBUS_RTU_PRIVATE_H
 
+#include <sys/time.h>
+
 #ifndef _MSC_VER
 #include <stdint.h>
 #else
@@ -71,6 +73,8 @@ typedef struct _modbus_rtu {
 #endif
     /* To handle many slaves on the same link */
     int confirmation_to_ignore;
+    int interframe_delay;
+    struct timeval last_frame_at;
 } modbus_rtu_t;
 
 #endif /* MODBUS_RTU_PRIVATE_H */

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -267,18 +267,91 @@ static void _modbus_rtu_ioctl_rts(modbus_t *ctx, int on)
 }
 #endif
 
+/* One character time in microseconds */
+static int _modbus_rtu_character_time(int baud, uint8_t data_bit, uint8_t stop_bit, char parity)
+{
+    return 1000000 * (1 + data_bit + (parity == 'N' ? 0 : 1) + stop_bit) / baud;
+}
+
+/* Silent interval between modbus frames in microseconds.  For baud rates
+ * greater than 19200 Bps returns a fixed value of 1750 us, otherwise 3.5
+ * character times.
+ */
+static int _modbus_rtu_t35(int baud, uint8_t data_bit, uint8_t stop_bit, char parity)
+{
+    int t35;
+    if (baud > 19200) {
+        t35 = 1750;
+    } else {
+        t35 = 3.5 * _modbus_rtu_character_time(baud, data_bit, stop_bit, parity);
+    }
+    return t35;
+}
+
+/* If gettimeofday() fails, set the timeval to 0 to indicate invalid value. */
+static void _modbus_rtu_update_last_frame_at(struct timeval *tv)
+{
+    if (gettimeofday(tv, NULL) == -1) {
+        tv->tv_sec = 0;
+        tv->tv_usec = 0;
+    }
+}
+
+/* If the last_frame_at value is valid (>0) and gettimeofday() doesn't fail,
+ * compute the distance of the time points [now - last_frame_at] and apply
+ * usleep() if needed to obey the interframe delay.
+ */
+static void _modbus_rtu_apply_interframe_delay(int interframe_delay, struct timeval *last)
+{
+    struct timeval now;
+    suseconds_t us;
+
+    if (last->tv_sec == 0 && last->tv_usec == 0) {
+        return;
+    }
+    if (gettimeofday(&now, NULL) == -1) {
+        return;
+    }
+    /* ensure last <= now */
+    if (now.tv_sec < last->tv_sec ||
+        (now.tv_sec == last->tv_sec && now.tv_usec < last->tv_usec)) {
+        return;
+    }
+
+    /* us := now - last */
+    us = now.tv_usec - last->tv_usec;
+    if (us < 0) {
+        us += 1000000;
+        now.tv_sec--;
+    }
+    us += (now.tv_sec - last->tv_sec) * 1000000;
+
+    /* check suseconds_t overflow (timepoints too distant) */
+    if (us < 0) {
+        return;
+    }
+    if (us < interframe_delay) {
+        usleep(interframe_delay - us);
+    }
+}
+
 static ssize_t _modbus_rtu_send(modbus_t *ctx, const uint8_t *req, int req_length)
 {
-#if defined(_WIN32)
+    ssize_t size;
     modbus_rtu_t *ctx_rtu = ctx->backend_data;
+
+    if (ctx_rtu->interframe_delay > 0) {
+        _modbus_rtu_apply_interframe_delay(ctx_rtu->interframe_delay, &ctx_rtu->last_frame_at);
+    }
+#if defined(_WIN32)
     DWORD n_bytes = 0;
-    return (WriteFile(ctx_rtu->w_ser.fd, req, req_length, &n_bytes, NULL)) ? (ssize_t)n_bytes : -1;
+    if (!WriteFile(ctx_rtu->w_ser.fd, req, req_length, &n_bytes, NULL)) {
+        return -1;
+    }
+    size = (ssize_t)n_bytes;
 #else
 #if HAVE_DECL_TIOCM_RTS
-    modbus_rtu_t *ctx_rtu = ctx->backend_data;
     if (ctx_rtu->rts != MODBUS_RTU_RTS_NONE) {
-        ssize_t size;
-
         if (ctx->debug) {
             fprintf(stderr, "Sending request using RTS signal\n");
         }
@@ -290,15 +363,17 @@ static ssize_t _modbus_rtu_send(modbus_t *ctx, const uint8_t *req, int req_lengt
 
         usleep(ctx_rtu->onebyte_time * req_length + ctx_rtu->rts_delay);
         ctx_rtu->set_rts(ctx, ctx_rtu->rts != MODBUS_RTU_RTS_UP);
-
-        return size;
     } else {
 #endif
-        return write(ctx->s, req, req_length);
+        size = write(ctx->s, req, req_length);
 #if HAVE_DECL_TIOCM_RTS
     }
 #endif
 #endif
+    if (size > 0 && ctx_rtu->interframe_delay > 0) {
+        _modbus_rtu_update_last_frame_at(&ctx_rtu->last_frame_at);
+    }
+    return size;
 }
 
 static int _modbus_rtu_receive(modbus_t *ctx, uint8_t *req)
@@ -326,11 +401,17 @@ static int _modbus_rtu_receive(modbus_t *ctx, uint8_t *req)
 
 static ssize_t _modbus_rtu_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length)
 {
+    ssize_t num_read;
+    modbus_rtu_t *ctx_rtu = ctx->backend_data;
 #if defined(_WIN32)
-    return win32_ser_read(&((modbus_rtu_t *)ctx->backend_data)->w_ser, rsp, rsp_length);
+    num_read = win32_ser_read(&((modbus_rtu_t *)ctx->backend_data)->w_ser, rsp, rsp_length);
 #else
-    return read(ctx->s, rsp, rsp_length);
+    num_read = read(ctx->s, rsp, rsp_length);
 #endif
+    if (num_read > 0 && ctx_rtu->interframe_delay > 0) {
+        _modbus_rtu_update_last_frame_at(&ctx_rtu->last_frame_at);
+    }
+    return num_read;
 }
 
 static int _modbus_rtu_flush(modbus_t *);
@@ -976,6 +1057,32 @@ int modbus_rtu_get_serial_mode(modbus_t *ctx)
     }
 }
 
+int modbus_rtu_set_interframe_delay(modbus_t *ctx, int us)
+{
+    if (ctx != NULL && ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU) {
+        modbus_rtu_t *ctx_rtu = ctx->backend_data;
+        if (us == MODBUS_RTU_INTERFRAME_AUTO) {
+            ctx_rtu->interframe_delay = _modbus_rtu_t35(ctx_rtu->baud, ctx_rtu->data_bit, ctx_rtu->stop_bit, ctx_rtu->parity);
+            return 0;
+        } else if (0 <= us && us < 1000000) {
+            ctx_rtu->interframe_delay = us;
+            return 0;
+        }
+    }
+    errno = EINVAL;
+    return -1;
+}
+
+int modbus_rtu_get_interframe_delay(modbus_t *ctx)
+{
+    if (ctx != NULL && ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU) {
+        modbus_rtu_t *ctx_rtu = ctx->backend_data;
+        return ctx_rtu->interframe_delay;
+    }
+    errno = EINVAL;
+    return -1;
+}
+
 int modbus_rtu_get_rts(modbus_t *ctx)
 {
     if (ctx == NULL) {
@@ -1298,7 +1405,7 @@ modbus_t* modbus_new_rtu(const char *device,
     ctx_rtu->rts = MODBUS_RTU_RTS_NONE;
 
     /* Calculate estimated time in micro second to send one byte */
-    ctx_rtu->onebyte_time = 1000000 * (1 + data_bit + (parity == 'N' ? 0 : 1) + stop_bit) / baud;
+    ctx_rtu->onebyte_time = _modbus_rtu_character_time(baud, data_bit, stop_bit, parity);
 
     /* The internal function is used by default to set RTS */
     ctx_rtu->set_rts = _modbus_rtu_ioctl_rts;
@@ -1308,6 +1415,9 @@ modbus_t* modbus_new_rtu(const char *device,
 #endif
 
     ctx_rtu->confirmation_to_ignore = FALSE;
+    ctx_rtu->interframe_delay = _modbus_rtu_t35(baud, data_bit, stop_bit, parity);
+    ctx_rtu->last_frame_at.tv_sec = 0;
+    ctx_rtu->last_frame_at.tv_usec = 0;
 
     return ctx;
 }

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -1233,8 +1233,28 @@ modbus_t* modbus_new_rtu(const char *device,
     }
 
     /* Check baud argument */
-    if (baud == 0) {
-        fprintf(stderr, "The baud rate value must not be zero\n");
+    if (baud <= 0) {
+        fprintf(stderr, "The baud rate value must be positive\n");
+        errno = EINVAL;
+        return NULL;
+    }
+
+    /* Check data_bit argument */
+    if (data_bit < 0) {
+        fprintf(stderr, "The data_bit value must be nonnegative\n");
+        errno = EINVAL;
+        return NULL;
+    }
+
+    /* Check stop_bit argument */
+    if (stop_bit < 0) {
+        fprintf(stderr, "The stop_bit value must be nonnegative\n");
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (parity != 'N' && parity != 'E' && parity != 'O') {
+        fprintf(stderr, "The parity must be one of: N, E, O\n");
         errno = EINVAL;
         return NULL;
     }
@@ -1264,13 +1284,7 @@ modbus_t* modbus_new_rtu(const char *device,
     strcpy(ctx_rtu->device, device);
 
     ctx_rtu->baud = baud;
-    if (parity == 'N' || parity == 'E' || parity == 'O') {
-        ctx_rtu->parity = parity;
-    } else {
-        modbus_free(ctx);
-        errno = EINVAL;
-        return NULL;
-    }
+    ctx_rtu->parity = parity;
     ctx_rtu->data_bit = data_bit;
     ctx_rtu->stop_bit = stop_bit;
 

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -25,6 +25,16 @@ MODBUS_API modbus_t* modbus_new_rtu(const char *device, int baud, char parity,
 MODBUS_API int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode);
 MODBUS_API int modbus_rtu_get_serial_mode(modbus_t *ctx);
 
+/* From Modbus_over_serial_line_V1_02.pdf (2.5.1.1 MODBUS Message RTU
+ * Framing): In RTU mode, message frames are separated by a silent interval
+ * of at least 3.5 character times (the interval is called "t3.5").  For
+ * baud rates greater than 19200 Bps, fixed value of 1.750ms is used.
+ */
+#define MODBUS_RTU_INTERFRAME_AUTO	-1
+
+MODBUS_API int modbus_rtu_set_interframe_delay(modbus_t *ctx, int us);
+MODBUS_API int modbus_rtu_get_interframe_delay(modbus_t *ctx);
+
 #define MODBUS_RTU_RTS_NONE   0
 #define MODBUS_RTU_RTS_UP     1
 #define MODBUS_RTU_RTS_DOWN   2


### PR DESCRIPTION
This code introduces the possibility to maintain a silent interval between MODBUS frames in RTU mode. The topic was already discussed in libmodbus google groups forum at the end of the year 2012 under the topic "3.5t timeout while transmitting":

https://groups.google.com/forum/#!topic/libmodbus/xZR66Gk_G2g

The code was only tested on Linux, I have no Windows setup.