### PR TITLE
fixed missing header file on installation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,7 +41,7 @@ endif
 
 # Header files to install
 libmodbusincludedir = $(includedir)/modbus
-libmodbusinclude_HEADERS = modbus.h modbus-version.h modbus-rtu.h modbus-tcp.h
+libmodbusinclude_HEADERS = modbus.h modbus-version.h modbus-rtu.h modbus-tcp.h modbus-serial.h modbus-ascii.h
 
 DISTCLEANFILES = modbus-version.h
 EXTRA_DIST += modbus-version.h.in


### PR DESCRIPTION
I tried to install using 'sudo make install' but I got a partial installation of the header files.
With this patch it works fine.