### PR TITLE
Add disabling flag for rtu address filtering

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -60,7 +60,9 @@ TXT3 = \
         modbus_write_bits.txt \
         modbus_write_bit.txt \
         modbus_write_registers.txt \
-        modbus_write_register.txt
+        modbus_write_register.txt \
+        modbus_rtu_get_recv_filter.txt \
+        modbus_rtu_set_recv_filter.txt
 TXT7 = libmodbus.txt
 
 EXTRA_DIST = asciidoc.conf $(TXT3) $(TXT7)

--- a/doc/modbus_rtu_get_recv_filter.txt
+++ b/doc/modbus_rtu_get_recv_filter.txt
@@ -1,0 +1,43 @@
+modbus_rtu_get_recv_filter(3)
+=============================
+
+
+NAME
+----
+modbus_rtu_get_recv_filter - get the current reception filter _flag_
+
+
+SYNOPSIS
+--------
+*int modbus_rtu_get_recv_filter(modbus_t *'ctx');*
+
+
+DESCRIPTION
+-----------
+The *modbus_rtu_get_recv_filter()* function shall get the current reception 
+filter flag of the libmodbus context _ctx_. The possible returned values are 
+`FALSE` or `TRUE`. By default, the boolean flag is set to `TRUE`. When the value 
+_flag_ is set to `TRUE`, only messages to the address of the slave defined in 
+the context and broadcast messages are returned by *modbus_receive*, the others
+are ignored. When the value _flag_ is set to `FALSE` all messages are returned 
+by *modbus_receive*.
+
+This function can only be used with a context using a RTU backend.
+
+
+RETURN VALUE
+------------
+The function shall return the current reception filter _flag_ if successful. 
+Otherwise it shall return -1 and set errno.
+
+
+SEE ALSO
+--------
+linkmb:modbus_receive[3]
+linkmb:modbus_rtu_get_recv_filter[3]
+
+
+AUTHORS
+-------
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/doc/modbus_rtu_set_recv_filter.txt
+++ b/doc/modbus_rtu_set_recv_filter.txt
@@ -1,0 +1,38 @@
+modbus_rtu_set_recv_filter(3)
+=============================
+
+NAME
+----
+modbus_rtu_set_recv_filter - set reception filter flag of the context
+
+
+SYNOPSIS
+--------
+*int modbus_rtu_set_recv_filter(modbus_t *'ctx', int 'flag');*
+
+
+DESCRIPTION
+-----------
+The *modbus_rtu_set_recv_filter()* function shall set the reception filter flag 
+of the *modbus_t* context by using the argument _flag_. By default, the boolean 
+flag is set to `TRUE`. When the value _flag_ is set to `TRUE`, only messages to 
+the address of the slave defined in the context and broadcast messages are 
+returned by *modbus_receive*, the others are ignored. When the value _flag_ is 
+set to `FALSE` all messages are returned by *modbus_receive*.
+
+This function can only be used with a context using a RTU backend.
+
+RETURN VALUE
+------------
+The function shall return 0 if successful. Otherwise it shall return -1 and set errno.
+
+
+SEE ALSO
+--------
+linkmb:modbus_receive[3]
+linkmb:modbus_rtu_get_recv_filter[3]
+
+AUTHORS
+-------
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -71,6 +71,7 @@ typedef struct _modbus_rtu {
 #endif
     /* To handle many slaves on the same link */
     int confirmation_to_ignore;
+    int disable_receive_filter;
 } modbus_rtu_t;
 
 #endif /* MODBUS_RTU_PRIVATE_H */

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -362,10 +362,12 @@ static int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
     uint16_t crc_calculated;
     uint16_t crc_received;
     int slave = msg[0];
+    modbus_rtu_t *ctx_rtu = ctx->backend_data;
 
     /* Filter on the Modbus unit identifier (slave) in RTU mode to avoid useless
      * CRC computing. */
-    if (slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS) {
+    if (slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS && 
+                                    ctx_rtu->disable_receive_filter == FALSE) {
         if (ctx->debug) {
             printf("Request for slave %d ignored (not %d)\n", slave, ctx->slave);
         }
@@ -1112,6 +1114,38 @@ int modbus_rtu_set_rts_delay(modbus_t *ctx, int us)
     }
 }
 
+int modbus_rtu_get_recv_filter(modbus_t *ctx)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU) {
+        modbus_rtu_t *ctx_rtu = ctx->backend_data;
+        return (ctx_rtu->disable_receive_filter == FALSE);
+    } 
+    errno = EINVAL;
+    return -1;
+}
+
+int modbus_rtu_set_recv_filter(modbus_t *ctx, int on)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU) {
+        modbus_rtu_t *ctx_rtu = ctx->backend_data;
+
+        ctx_rtu->disable_receive_filter = (on == FALSE);
+    }
+    /* Wrong backend specified */
+    errno = EINVAL;
+    return -1;
+}
+
 static void _modbus_rtu_close(modbus_t *ctx)
 {
     /* Restore line settings and close file descriptor in RTU mode */
@@ -1294,6 +1328,7 @@ modbus_t* modbus_new_rtu(const char *device,
 #endif
 
     ctx_rtu->confirmation_to_ignore = FALSE;
+    ctx_rtu->disable_receive_filter = FALSE;
 
     return ctx;
 }

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -37,6 +37,9 @@ MODBUS_API int modbus_rtu_set_custom_rts(modbus_t *ctx, void (*set_rts) (modbus_
 MODBUS_API int modbus_rtu_set_rts_delay(modbus_t *ctx, int us);
 MODBUS_API int modbus_rtu_get_rts_delay(modbus_t *ctx);
 
+MODBUS_API int modbus_rtu_set_recv_filter(modbus_t *ctx, int on);
+MODBUS_API int modbus_rtu_get_recv_filter(modbus_t *ctx);
+
 MODBUS_END_DECLS
 
 #endif /* MODBUS_RTU_H */


### PR DESCRIPTION
Hi,
I developed a complementary project to libmodbus which allows you to use your work in C++ and adds functionalities. This project is  [libmodbuspp](https://github.com/epsilonrt/libmodbuspp).

The current RTU implementation of libmodbus (in `_modbus_rtu_check_integrity()`), filters messages that are not intended for the context slave.

This poses a problem when you want to manage more than one slave on a serial link (for the [Modbus::Server](http://www.epsilonrt.fr/modbuspp/classModbus_1_1Server.html) class of libmodbuspp for example).

This pull request makes it possible to add the possibility of disabling this address filtering in the RTU reception function.

I would therefore be very satisfied if you could integrate this modification into libmodbus.

Regards