### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ To compile under OS X with [homebrew](http://mxcl.github.com/homebrew/), you
 will need to install the following dependencies first: `brew install autoconf
 automake libtool`.
 
+Building libmodbus - Using vcpkg
+--------------------------------
+
+You can download and install libmodbus using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install libmodbus
+
+The libmodbus port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Documentation
 -------------
 


### PR DESCRIPTION
Libmodbus is available as a port in vcpkg, a C++ library manager that simplifies installation for libmodbus and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libmodbus, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.