### PR TITLE
New functions to enable/disable various quirks (non-compliant)

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,6 +1,8 @@
 TXT3 = \
         modbus_close.txt \
         modbus_connect.txt \
+        modbus_disable_quirks.txt \
+        modbus_enable_quirks.txt \
         modbus_flush.txt \
         modbus_free.txt \
         modbus_get_byte_from_bits.txt \

--- a/doc/modbus_disable_quirks.txt
+++ b/doc/modbus_disable_quirks.txt
@@ -1,0 +1,44 @@
+modbus_disable_quirks(3)
+========================
+
+
+NAME
+----
+modbus_disable_quirks - disable quirk handler
+
+
+SYNOPSIS
+--------
+*int modbus_disable_quirks(modbus_t *'ctx', int 'quirks_mask');*
+
+
+DESCRIPTION
+-----------
+The *modbus_disable_quirks()* function disables all quirks given in _quirks_mask_
+in the libmodbus context. See linkmb:modbus_enable_quirks[3] for details and a
+list of available quirks.
+
+Several quirks can be disabled at same time by using logical-or.
+
+
+RETURN VALUE
+------------
+The function shall return zero if successful. Otherwise it shall
+return -1 and set errno.
+
+
+ERRORS
+------
+*EINVAL*::
+The argument _ctx_ is NULL.
+
+
+SEE ALSO
+--------
+linkmb:modbus_enable_quirks[3]
+
+
+AUTHORS
+-------
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/doc/modbus_enable_quirks.txt
+++ b/doc/modbus_enable_quirks.txt
@@ -1,0 +1,44 @@
+modbus_enable_quirks(3)
+=======================
+
+
+NAME
+----
+modbus_enable_quirks - enable quirk handler
+
+
+SYNOPSIS
+--------
+*int modbus_enable_quirks(modbus_t *'ctx', int 'quirks_mask');*
+
+
+DESCRIPTION
+-----------
+The *modbus_enable_quirks()* function enables all quirks given in _quirks_mask_
+in the libmodbus context:
+
+*MODBUS_QUIRK_INVAL_ADDR*:: If enabled it allows the use of non-compliant slave
+ addresses, i.e. zero (normally the broadcast address) and addresses above 247.
+
+*MODBUS_QUIRK_BCAST_RESP*:: In slave mode libmodbus must not respond to requests
+ to the broadcast address, neither a normal response nor an exception in case of
+ an error. Enabling this quirk forces an appropriate reply.
+
+Several quirks can be enabled at same time by using logical-or.
+
+
+RETURN VALUE
+------------
+The function shall return zero if successful. Otherwise it shall
+return -1 and set errno.
+
+
+SEE ALSO
+--------
+linkmb:modbus_disable_quirks[3]
+
+
+AUTHORS
+-------
+The libmodbus documentation was written by Stéphane Raimbault
+<stephane.raimbault@gmail.com>

--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -96,6 +96,7 @@ struct _modbus {
     int s;
     int debug;
     int error_recovery;
+    int quirks;
     struct timeval response_timeout;
     struct timeval byte_timeout;
     struct timeval indication_timeout;

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -91,8 +91,11 @@ static const uint8_t table_crc_lo[] = {
  * internal slave ID in slave mode */
 static int _modbus_set_slave(modbus_t *ctx, int slave)
 {
+    /* Enabled quirk allows to set slave address to none-conforming address. */
+
     /* Broadcast address is 0 (MODBUS_BROADCAST_ADDRESS) */
-    if (slave >= 0 && slave <= 247) {
+    if ((slave >= 0 && slave <= 247) ||
+        (ctx->quirks & MODBUS_QUIRK_INVAL_ADDR)) {
         ctx->slave = slave;
     } else {
         errno = EINVAL;

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -76,8 +76,11 @@ static int _modbus_tcp_init_win32(void)
 
 static int _modbus_set_slave(modbus_t *ctx, int slave)
 {
+    /* Enabled quirk allows to set slave address to none-conforming address. */
+
     /* Broadcast address is 0 (MODBUS_BROADCAST_ADDRESS) */
-    if (slave >= 0 && slave <= 247) {
+    if ((slave >= 0 && slave <= 247) ||
+        (ctx->quirks & MODBUS_QUIRK_INVAL_ADDR)) {
         ctx->slave = slave;
     } else if (slave == MODBUS_TCP_SLAVE) {
         /* The special value MODBUS_TCP_SLAVE (0xFF) can be used in TCP mode to

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -997,8 +997,11 @@ int modbus_reply(modbus_t *ctx, const uint8_t *req,
         break;
     }
 
-    /* Suppress any responses when the request was a broadcast */
+    /* Suppress any responses when the request was a broadcast unless: */
+    /* a) we are in a TCP context */
+    /* b) quirk is enabled */
     return (ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU &&
+            !(ctx->quirks & MODBUS_QUIRK_BCAST_RESP) &&
             slave == MODBUS_BROADCAST_ADDRESS) ? 0 : send_msg(ctx, rsp, rsp_length);
 }
 
@@ -1757,6 +1760,30 @@ int modbus_set_debug(modbus_t *ctx, int flag)
     }
 
     ctx->debug = flag;
+    return 0;
+}
+
+/* Enable quirks in context's mask */
+int modbus_enable_quirks(modbus_t *ctx, int quirks_mask)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    ctx->quirks |= quirks_mask;
+    return 0;
+}
+
+/* Disable quirks in context's mask */
+int modbus_disable_quirks(modbus_t *ctx, int quirks_mask)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    ctx->quirks &= ~quirks_mask;
     return 0;
 }
 

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -57,6 +57,10 @@ MODBUS_BEGIN_DECLS
 #define ON 1
 #endif
 
+#ifndef BIT
+#define BIT(x) (1 << (x))
+#endif
+
 /* Modbus function codes */
 #define MODBUS_FC_READ_COILS                0x01
 #define MODBUS_FC_READ_DISCRETE_INPUTS      0x02
@@ -176,6 +180,15 @@ typedef enum
     MODBUS_ERROR_RECOVERY_PROTOCOL      = (1<<2)
 } modbus_error_recovery_mode;
 
+/* The following flags indicate to libmodbus, that various 'quirks' handlers should be enabled.
+ * Please note, that using such 'quirks' is _not_ Modbus compliant, so use at your own risk :-)
+ *
+ * MODBUS_QUIRK_INVAL_ADDR       - allows the use of modbus addresses 0 and 248-255
+ * MODBUS_QUIRK_BCAST_RESP       - respond to broadcast requests
+ */
+#define MODBUS_QUIRK_INVAL_ADDR         BIT(0)
+#define MODBUS_QUIRK_BCAST_RESP         BIT(1)
+
 MODBUS_API int modbus_set_slave(modbus_t* ctx, int slave);
 MODBUS_API int modbus_get_slave(modbus_t* ctx);
 MODBUS_API int modbus_set_error_recovery(modbus_t *ctx, modbus_error_recovery_mode error_recovery);
@@ -192,6 +205,9 @@ MODBUS_API int modbus_get_indication_timeout(modbus_t *ctx, uint32_t *to_sec, ui
 MODBUS_API int modbus_set_indication_timeout(modbus_t *ctx, uint32_t to_sec, uint32_t to_usec);
 
 MODBUS_API int modbus_get_header_length(modbus_t *ctx);
+
+MODBUS_API int modbus_enable_quirks(modbus_t *ctx, int quirks_mask);
+MODBUS_API int modbus_disable_quirks(modbus_t *ctx, int quirks_mask);
 
 MODBUS_API int modbus_connect(modbus_t *ctx);
 MODBUS_API void modbus_close(modbus_t *ctx);

--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -445,11 +445,27 @@ int main(int argc, char *argv[])
     printf("* modbus_write_registers: ");
     ASSERT_TRUE(rc == -1 && errno == EMBMDATA, "");
 
+    /** TEST SLAVE ADDRESS **/
+    printf("\nTEST SLAVE ADDRESS:\n");
+
+    printf("1/2 Not compliant slave address refused: ");
+    rc = modbus_set_slave(ctx, 248);
+    ASSERT_TRUE(rc == -1, "Slave address must not be allowed");
+
+    printf("2/2 Not compliant slave address allowed: ");
+    modbus_enable_quirks(ctx, MODBUS_QUIRK_INVAL_ADDR);
+    rc = modbus_set_slave(ctx, 248);
+    ASSERT_TRUE(rc == 0, "Not compliant slave address refused");
+    modbus_disable_quirks(ctx, MODBUS_QUIRK_INVAL_ADDR);
+
     /** SLAVE REPLY **/
     old_slave = modbus_get_slave(ctx);
 
     printf("\nTEST SLAVE REPLY:\n");
-    modbus_set_slave(ctx, INVALID_SERVER_ID);
+
+    rc = modbus_set_slave(ctx, INVALID_SERVER_ID);
+    ASSERT_TRUE(rc == 0, "Server ID for tests");
+
     rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS,
                                UT_REGISTERS_NB, tab_rp_registers);
     if (use_backend == RTU) {
@@ -502,7 +518,7 @@ int main(int argc, char *argv[])
         ASSERT_TRUE(rc == UT_REGISTERS_NB, "");
 
         rc = modbus_set_slave(ctx, MODBUS_BROADCAST_ADDRESS);
-        ASSERT_TRUE(rc != -1, "Invalid broacast address");
+        ASSERT_TRUE(rc == 0, "Set broadcast address");
 
         rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS,
                                    UT_REGISTERS_NB, tab_rp_registers);

--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -452,6 +452,9 @@ int main(int argc, char *argv[])
     rc = modbus_set_slave(ctx, 248);
     ASSERT_TRUE(rc == -1, "Slave address must not be allowed");
 
+    /* Save slave address for next tests before testing for quirks */
+    old_slave = modbus_get_slave(ctx);
+
     printf("2/2 Not compliant slave address allowed: ");
     modbus_enable_quirks(ctx, MODBUS_QUIRK_INVAL_ADDR);
     rc = modbus_set_slave(ctx, 248);
@@ -459,8 +462,6 @@ int main(int argc, char *argv[])
     modbus_disable_quirks(ctx, MODBUS_QUIRK_INVAL_ADDR);
 
     /** SLAVE REPLY **/
-    old_slave = modbus_get_slave(ctx);
-
     printf("\nTEST SLAVE REPLY:\n");
 
     rc = modbus_set_slave(ctx, INVALID_SERVER_ID);


### PR DESCRIPTION
Dear @stephane 
I've got a device that can be only communicated using 'any address' 0xFE, which libmodbus refuses to do in a good will to comply to the standard. However, it is good to have an option to do so.
I have found a stale branch 'compliance' which was not merged and also an implementation from @mhei that I applied to the current master without any code changes.
Could this one be merged?
Please let me know if you need some changes in it.