### PR TITLE
Install NEWS and AUTHORS files with library, ship LICENSE with tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ pkgconfig_DATA = libmodbus.pc
 EXTRA_DIST = libmodbus.pc.in
 CLEANFILES += libmodbus.pc
 
-dist_doc_DATA = MIGRATION README.md
+dist_doc_DATA = MIGRATION README.md AUTHORS NEWS
 
 SUBDIRS = src doc
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST = README.md unit-tests.sh
+EXTRA_DIST = README.md unit-tests.sh LICENSE
 
 noinst_PROGRAMS = \
 	bandwidth-server-one \


### PR DESCRIPTION
Ensure that relevant documentation files are shipped and installed with the library and the tests.

Install NEWS and AUTHORS files to doc dir alongside MIGRATION and README.md. Patched by Michael Weber in the Gentoo package for 3.1.4
Fixes #513 

Include the test license in the source tarball.
Fixes #542