### PR TITLE
File registers

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -60,6 +60,7 @@ TXT3 = \
         modbus_write_and_read_registers.txt \
         modbus_write_bits.txt \
         modbus_write_bit.txt \
+        modbus_write_file_record.txt \
         modbus_write_registers.txt \
         modbus_write_register.txt
 TXT7 = libmodbus.txt

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -12,7 +12,7 @@ TXT3 = \
         modbus_get_float_dcba.txt \
         modbus_get_header_length.txt \
         modbus_get_response_timeout.txt \
-	modbus_get_slave.txt \
+        modbus_get_slave.txt \
         modbus_get_socket.txt \
         modbus_mapping_free.txt \
         modbus_mapping_new.txt \
@@ -22,6 +22,7 @@ TXT3 = \
         modbus_new_tcp_pi.txt \
         modbus_new_tcp.txt \
         modbus_read_bits.txt \
+        modbus_read_file_record.txt \
         modbus_read_input_bits.txt \
         modbus_read_input_registers.txt \
         modbus_read_registers.txt \

--- a/doc/modbus_read_file_record.txt
+++ b/doc/modbus_read_file_record.txt
@@ -1,0 +1,42 @@
+modbus_read_file_record(3)
+==========================
+
+
+NAME
+----
+modbus_read_file_record - Read values from a file register
+
+
+SYNOPSIS
+--------
+*int modbus_read_file_record(modbus_t *'ctx', int 'addr', int 'sub_addr', int 'nb', uint16_t '*dest');*
+
+
+DESCRIPTION
+-----------
+The *modbus_read_file_record()* function reads _nb_ values from file
+register _addr_, starting from position _sub_addr_ in the file register.
+
+A file register is an array of values.
+A modbus device may have up to 65535 file registers, addressed 1 to 65535
+decimal.
+Each file register contains 10000 values, addressed 0000 to 9999 decimal.
+
+This function uses the Modbus function code 0x14 (Read File Record).
+
+
+RETURN VALUE
+------------
+The function shall return the number of records read (i.e. the value of _nb_) if successful.
+Otherwise it shall return -1 and set errno.
+
+
+SEE ALSO
+--------
+linkmb:modbus_read_register[3]
+linkmb:modbus_write_file_register[3]
+
+
+AUTHORS
+-------
+The libmodbus file register support was added by Richard Ash at EA Technology.

--- a/doc/modbus_write_file_record.txt
+++ b/doc/modbus_write_file_record.txt
@@ -1,20 +1,20 @@
-modbus_read_file_record(3)
+modbus_write_file_record(3)
 ==========================
 
 
 NAME
 ----
-modbus_read_file_record - Read values from a file register
+modbus_write_file_record - Write values to a file register
 
 
 SYNOPSIS
 --------
-*int modbus_read_file_record(modbus_t *'ctx', int 'addr', int 'sub_addr', int 'nb', uint16_t '*dest');*
+*int modbus_write_file_record(modbus_t *'ctx', int 'addr', int 'sub_addr', int 'nb', const uint16_t '*src');*
 
 
 DESCRIPTION
 -----------
-The *modbus_read_file_record()* function reads _nb_ values from file
+The *modbus_write_file_record()* function writes _nb_ values to file
 register _addr_, starting from position _sub_addr_ in the file register.
 
 A file register is an array of values.
@@ -22,19 +22,19 @@ A modbus device may have up to 65535 file registers, addressed 1 to 65535
 decimal.
 Each file register contains 10000 values, addressed 0000 to 9999 decimal.
 
-This function uses the Modbus function code 0x14 (Read File Record).
+This function uses the Modbus function code 0x15 (Write File Record).
 
 
 RETURN VALUE
 ------------
-The function shall return the number of records read (i.e. the value of _nb_) if successful.
+The function shall return the number of records written (i.e. the value of _nb_) if successful.
 Otherwise it shall return -1 and set errno.
 
 
 SEE ALSO
 --------
-linkmb:modbus_read_register[3]
-linkmb:modbus_write_file_register[3]
+linkmb:modbus_write_register[3]
+linkmb:modbus_read_file_register[3]
 
 
 AUTHORS

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1278,7 +1278,7 @@ int modbus_read_file_record(modbus_t *ctx, int addr, int sub_addr, int nb, uint1
         errno = EINVAL;
         return -1;
     }
-
+	// check if record number is within range
     if (sub_addr > MODBUS_MAX_FILE_RECORD_NUMBER) {
         if (ctx->debug) {
             fprintf(stderr,
@@ -1317,7 +1317,8 @@ int modbus_read_file_record(modbus_t *ctx, int addr, int sub_addr, int nb, uint1
             return -1;
 
         offset = ctx->backend->header_length;
-
+        // if all went well, copy returned data to caller's pointer, converting
+        // bytes into 16-bit words.
         for (i = 0; i < rc; i++) {
 
             dest[i] = (rsp[offset + 4 + (i << 1)] << 8) |
@@ -1505,7 +1506,7 @@ int modbus_write_file_record(modbus_t *ctx, int addr, int sub_addr, int nb, cons
         errno = EINVAL;
         return -1;
     }
-
+    // check record number is valid
     if (sub_addr > MODBUS_MAX_FILE_RECORD_NUMBER) {
         if (ctx->debug) {
             fprintf(stderr,
@@ -1530,7 +1531,7 @@ int modbus_write_file_record(modbus_t *ctx, int addr, int sub_addr, int nb, cons
     req[req_length++] = sub_addr & 0x00ff;
     req[req_length++] = nb >> 8;
     req[req_length++] = nb & 0x00ff;
-
+	// pack supplied data into request
     for (i = 0; i < nb; i++) {
         req[req_length++] = src[i] >> 8;
         req[req_length++] = src[i] & 0x00FF;

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -68,6 +68,8 @@ MODBUS_BEGIN_DECLS
 #define MODBUS_FC_WRITE_MULTIPLE_COILS      0x0F
 #define MODBUS_FC_WRITE_MULTIPLE_REGISTERS  0x10
 #define MODBUS_FC_REPORT_SLAVE_ID           0x11
+#define MODBUS_FC_READ_FILE_RECORD          0x14
+#define MODBUS_FC_WRITE_FILE_RECORD         0x15
 #define MODBUS_FC_MASK_WRITE_REGISTER       0x16
 #define MODBUS_FC_WRITE_AND_READ_REGISTERS  0x17
 
@@ -80,6 +82,11 @@ MODBUS_BEGIN_DECLS
  */
 #define MODBUS_MAX_READ_BITS              2000
 #define MODBUS_MAX_WRITE_BITS             1968
+
+/* Modbus_Application_Protocol_V1_1b.pdf (chapter 6 section 14 page 33)
+ * Sub-Req. x, Record Number (2 bytes): 1 to 9999 (0x270F)
+ */
+#define MODBUS_MAX_FILE_RECORD_NUMBER     9999
 
 /* Modbus_Application_Protocol_V1_1b.pdf (chapter 6 section 3 page 15)
  * Quantity of Registers to read (2 bytes): 1 to 125 (0x7D)
@@ -211,6 +218,8 @@ MODBUS_API int modbus_write_bit(modbus_t *ctx, int coil_addr, int status);
 MODBUS_API int modbus_write_register(modbus_t *ctx, int reg_addr, const uint16_t value);
 MODBUS_API int modbus_write_bits(modbus_t *ctx, int addr, int nb, const uint8_t *data);
 MODBUS_API int modbus_write_registers(modbus_t *ctx, int addr, int nb, const uint16_t *data);
+MODBUS_API int modbus_write_file_record(modbus_t *ctx, int addr, int sub_addr, int nb, const uint16_t *src);
+MODBUS_API int modbus_read_file_record(modbus_t *ctx, int addr, int sub_addr, int nb, uint16_t *dest);
 MODBUS_API int modbus_mask_write_register(modbus_t *ctx, int addr, uint16_t and_mask, uint16_t or_mask);
 MODBUS_API int modbus_write_and_read_registers(modbus_t *ctx, int write_addr, int write_nb,
                                                const uint16_t *src, int read_addr, int read_nb,


### PR DESCRIPTION
Support for ModBus file registers, part 1.

This implements ModBus master support for reading and writing a single contiguous range of values in a file register (the protocol supports multiple ranges of values in a single requests, but this implementation does not).
This is the first (and hopefully not controversial) part of the changes, which extends the API but does not make any changes / breakages to it.