### PR TITLE
Modbus/TCP Security

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,17 @@ AC_ARG_ENABLE(tests,
 	[enable_tests=yes])
 AM_CONDITIONAL(BUILD_TESTS, [test $enable_tests != no])
 
+AC_ARG_ENABLE(tls,
+	AS_HELP_STRING([--enable-tls],
+	[Build with SSL/TLS support (default: no)]),
+	[enable_tls=yes],[enable_tls=no])
+AM_CONDITIONAL(BUILD_TLS, [test $enable_tls != no])
+
+AS_IF([test $enable_tls != no],
+	[AC_DEFINE([USE_TLS], [1], [Define if SSL/TLS feature is enabled])]
+	[AC_CHECK_LIB([ssl], [SSL_new])]
+	[AC_CHECK_LIB([crypto], [CRYPTO_new_ex_data])],)
+
 AC_CONFIG_HEADERS([config.h tests/unit-test.h])
 AC_CONFIG_FILES([
         Makefile
@@ -176,6 +187,7 @@ AC_MSG_RESULT([
         cflags:                 ${CFLAGS}
         ldflags:                ${LDFLAGS}
 
+        tls:                    ${enable_tls}
         documentation:          ${ac_libmodbus_build_doc}
         tests:                  ${enable_tests}
 ])

--- a/src/modbus-tcp-private.h
+++ b/src/modbus-tcp-private.h
@@ -41,4 +41,18 @@ typedef struct _modbus_tcp_pi {
     char service[_MODBUS_TCP_PI_SERVICE_LENGTH];
 } modbus_tcp_pi_t;
 
+#if defined(USE_TLS)
+typedef struct _modbus_tls {
+    /* Transaction ID */
+    uint16_t t_id;
+    /* TCP port */
+    int port;
+    /* IP address */
+    char ip[16];
+    /* TLS context and connection */
+    SSL_CTX *ctx;
+    SSL *ssl;
+} modbus_tls_t;
+#endif
+
 #endif /* MODBUS_TCP_PRIVATE_H */

--- a/src/modbus-tcp.h
+++ b/src/modbus-tcp.h
@@ -47,6 +47,10 @@ MODBUS_API modbus_t* modbus_new_tcp_pi(const char *node, const char *service);
 MODBUS_API int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection);
 MODBUS_API int modbus_tcp_pi_accept(modbus_t *ctx, int *s);
 
+MODBUS_API modbus_t* modbus_new_tls(const char *ip_address, int port, const char *cert, const char *key, const char *ca);
+MODBUS_API int modbus_tls_listen(modbus_t *ctx, int nb_connection);
+MODBUS_API int modbus_tls_accept(modbus_t *ctx, int *s);
+
 MODBUS_END_DECLS
 
 #endif /* MODBUS_TCP_H */

--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -18,7 +18,10 @@ const int EXCEPTION_RC = 2;
 enum {
     TCP,
     TCP_PI,
-    RTU
+    RTU,
+#if defined(USE_TLS)
+    TLS
+#endif
 };
 
 int test_server(modbus_t *ctx, int use_backend);
@@ -73,8 +76,15 @@ int main(int argc, char *argv[])
             use_backend = TCP_PI;
         } else if (strcmp(argv[1], "rtu") == 0) {
             use_backend = RTU;
+        } else if (strcmp(argv[1], "tls") == 0) {
+#if defined(USE_TLS)
+            use_backend = TLS;
+#elif
+            printf("Compiled without TLS support.\n");
+            return -1;
+#endif
         } else {
-            printf("Usage:\n  %s [tcp|tcppi|rtu] - Modbus client for unit testing\n\n", argv[0]);
+            printf("Usage:\n  %s [tcp|tcppi|rtu|tls] - Modbus client for unit testing\n\n", argv[0]);
             exit(1);
         }
     } else {
@@ -86,6 +96,10 @@ int main(int argc, char *argv[])
         ctx = modbus_new_tcp("127.0.0.1", 1502);
     } else if (use_backend == TCP_PI) {
         ctx = modbus_new_tcp_pi("::1", "1502");
+#if defined(USE_TLS)
+    } else if (use_backend == TLS) {
+        ctx = modbus_new_tls("127.0.0.1", 1502, "client.pem", "client.key", "ca.pem");
+#endif
     } else {
         ctx = modbus_new_rtu("/dev/ttyUSB1", 115200, 'N', 8, 1);
     }

--- a/tests/unit-test.h.in
+++ b/tests/unit-test.h.in
@@ -10,6 +10,7 @@
 /* Constants defined by configure.ac */
 #define HAVE_INTTYPES_H @HAVE_INTTYPES_H@
 #define HAVE_STDINT_H @HAVE_STDINT_H@
+#define USE_TLS @USE_TLS@
 
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>


### PR DESCRIPTION
This is a first approach to adding TLS support to libmodbus, by creating a new `modbus_backend_t`. Although functional, the [Modbus/TCP Security](https://modbus.org/docs/MB-TCP-Security-v21_2018-07-24.pdf) is not fully implemented, notably missing Role-Based Client Authorization.

OpenSSL is used as the TLS implementation, currently tested with version 1.1.1. The new "`--enable-tls`" option, witch defaults to "no", is added to control the inclusion of this new dependency. I also developed this backend based on mbedTLS, but omited it here since OpenSSL seems to be a more sensible option for general use cases. If desired, I can send the patches to make "`--enable-tls`" select which lib to use.

In the second patch, in `modbus-tcp.c`, when `send`-ing (line 182 to 223) or `recv`-ing (line 235 to 276), it may be necessary to `select` for read or write. I'm not sure whitch timeout to use for these calls, so I left it with NULL and marked the code with "TODOs". The code works this way, but its not a desirable solution.

This work was funded by the Research and Development project PD 2866-0468/2017, granted by the Brazilian Electricity Regulatory Agency (ANEEL) and Companhia Paranaense de Energia (COPEL). Some results using the mbedTLS backend where presented at [INDUSCON 2018](https://doi.org/10.1109/INDUSCON.2018.8627306) and [COBEP 2019](https://doi.org/10.1109/COBEP/SPEC44138.2019.9065406).
