### PR TITLE
docs: fix simple typo, reponse -> response

### DIFF
--- a/tests/bandwidth-client.c
+++ b/tests/bandwidth-client.c
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
     printf("* %d KiB/s\n", rate);
     printf("\n");
 
-    /* TCP: Query and reponse header and values */
+    /* TCP: Query and response header and values */
     bytes = 12 + 9 + (nb_points / 8) + ((nb_points % 8) ? 1 : 0);
     printf("Values and TCP Modbus overhead:\n");
     printf("* %d x %d bytes\n", n_loop, bytes);
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
     printf("* %d KiB/s\n", rate);
     printf("\n");
 
-    /* TCP:Query and reponse header and values */
+    /* TCP:Query and response header and values */
     bytes = 12 + 9 + (nb_points * sizeof(uint16_t));
     printf("Values and TCP Modbus overhead:\n");
     printf("* %d x %d bytes\n", n_loop, bytes);
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
     printf("* %d KiB/s\n", rate);
     printf("\n");
 
-    /* TCP:Query and reponse header and values */
+    /* TCP:Query and response header and values */
     bytes = 12 + 9 + (nb_points * sizeof(uint16_t));
     printf("Values and TCP Modbus overhead:\n");
     printf("* %d x %d bytes\n", n_loop, bytes);


### PR DESCRIPTION
There is a small typo in tests/bandwidth-client.c.

Should read `response` rather than `reponse`.

