### PR TITLE
Update libmodbus.txt

### DIFF
--- a/doc/libmodbus.txt
+++ b/doc/libmodbus.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 --------
 *#include <modbus.h>*
 
-*cc* \`pkg-config --cflags --libs libmodbus` 'files'
+*cc* 'files' \`pkg-config --cflags --libs libmodbus`
 
 
 DESCRIPTION


### PR DESCRIPTION
Current versions of cc require that the pkg-config flags are to the right of the filename