### PR TITLE
code cleanups

### DIFF
--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -1197,6 +1197,7 @@ static void _modbus_rtu_free(modbus_t *ctx) {
     }
 
     free(ctx);
+    ctx = NULL;
 }
 
 const modbus_backend_t _modbus_rtu_backend = {
@@ -1252,7 +1253,6 @@ modbus_t* modbus_new_rtu(const char *device,
     ctx->backend_data = (modbus_rtu_t *)malloc(sizeof(modbus_rtu_t));
     if (ctx->backend_data == NULL) {
         modbus_free(ctx);
-        errno = ENOMEM;
         return NULL;
     }
     ctx_rtu = (modbus_rtu_t *)ctx->backend_data;
@@ -1261,7 +1261,6 @@ modbus_t* modbus_new_rtu(const char *device,
     ctx_rtu->device = (char *)malloc((strlen(device) + 1) * sizeof(char));
     if (ctx_rtu->device == NULL) {
         modbus_free(ctx);
-        errno = ENOMEM;
         return NULL;
     }
     strcpy(ctx_rtu->device, device);

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -742,6 +742,8 @@ static int _modbus_tcp_select(modbus_t *ctx, fd_set *rset, struct timeval *tv, i
 static void _modbus_tcp_free(modbus_t *ctx) {
     free(ctx->backend_data);
     free(ctx);
+
+    ctx = NULL;
 }
 
 const modbus_backend_t _modbus_tcp_backend = {
@@ -823,7 +825,6 @@ modbus_t* modbus_new_tcp(const char *ip, int port)
     ctx->backend_data = (modbus_tcp_t *)malloc(sizeof(modbus_tcp_t));
     if (ctx->backend_data == NULL) {
         modbus_free(ctx);
-        errno = ENOMEM;
         return NULL;
     }
     ctx_tcp = (modbus_tcp_t *)ctx->backend_data;
@@ -875,7 +876,6 @@ modbus_t* modbus_new_tcp_pi(const char *node, const char *service)
     ctx->backend_data = (modbus_tcp_pi_t *)malloc(sizeof(modbus_tcp_pi_t));
     if (ctx->backend_data == NULL) {
         modbus_free(ctx);
-        errno = ENOMEM;
         return NULL;
     }
     ctx_tcp_pi = (modbus_tcp_pi_t *)ctx->backend_data;

--- a/tests/unit-test-server.c
+++ b/tests/unit-test-server.c
@@ -92,7 +92,7 @@ int main(int argc, char*argv[])
 
     /* Initialize values of INPUT REGISTERS */
     for (i=0; i < UT_INPUT_REGISTERS_NB; i++) {
-        mb_mapping->tab_input_registers[i] = UT_INPUT_REGISTERS_TAB[i];;
+        mb_mapping->tab_input_registers[i] = UT_INPUT_REGISTERS_TAB[i];
     }
 
     if (use_backend == TCP) {


### PR DESCRIPTION
some code cleanups:
- unnecessary errno settings for malloc fails.
- set ctx to NULL after free calls.
