### PR TITLE
fixed double free for serial RTU

### DIFF
--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -182,7 +182,6 @@ static int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg,
 
 static void _modbus_rtu_free(modbus_t *ctx) {
   _modbus_serial_free(ctx->backend_data);
-  free(ctx->backend_data);
   free(ctx);
 }
 


### PR DESCRIPTION
# Error
**Double Free:**
On cleanup, 
the `_modbus_rtu_free` function in `src/modbus-rtu.c` calls 
the `_modbus_serial_free` function from `src/modbus-serial.c`.

```c
// src/modbus-rtu.c
static void _modbus_rtu_free(modbus_t *ctx) {
  _modbus_serial_free(ctx->backend_data);
  free(ctx->backend_data);
  free(ctx);
}
```

```c
// src/modbus-serial.c
void _modbus_serial_free(modbus_serial_t *ctx_serial)
{
    if (ctx_serial) {
        free(ctx_serial->device);
    }
    free(ctx_serial);
}
```

The `ctx->backend_data` which is given to `_modbus_serial_free` (now called `ctx_serial`) is freed twice.
- in `_modbus_serial_free` in `free(ctx_serial)`
- and in `_modbus_rtu_free` in `free(ctx->backend_data)`


# FIX
To fix this remove the `free(ctx->backend_data)` to stay symmetrical to `_modbus_ascii_free`

```diff
 // src/modbus-rtu.c
 static void _modbus_rtu_free(modbus_t *ctx) {
   _modbus_serial_free(ctx->backend_data);
-  free(ctx->backend_data);
   free(ctx);
 }
```
