### PR TITLE
Make sub-command more clear

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ LICENSE file).
 After installation, you can use pkg-config to compile these tests.
 For example, to compile random-test-server run:
 
-gcc random-test-server.c -o random-test-server `pkg-config --libs --cflags libmodbus`
+`gcc random-test-server.c -o random-test-server $(pkg-config --libs --cflags libmodbus)`
 
 - `random-test-server` is necessary to launch a server before running
 random-test-client. By default, it receives and replies to Modbus query on the


### PR DESCRIPTION
In tests readme, sub-command is using backtick (\`), but in Markdown file escaped as **code**. Thats make new user think that `pkg-config ...` is a parameter for gcc.

This pull make it more clear and use `$( ... )` sub-command style. Thanks.