### PR TITLE
VCLinkerTool version 1.0.0 to 1.0, NO link error

### DIFF
--- a/src/win32/modbus.vcproj
+++ b/src/win32/modbus.vcproj
@@ -78,7 +78,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="ws2_32.lib"
-				Version="1.0.0"
+				Version="1.0"
 				LinkIncremental="1"
 				AdditionalLibraryDirectories=""
 				GenerateManifest="true"


### PR DESCRIPTION
Even the newest visual studio use /VERSION:major[.minor]  .  
It means link.exe  /VERSION:1.0  just  need two version number .
If Version = 1.0.0 , when visual studio  link the program , vs will produce link error:

```
1>"/OUT:C:\Users\Lenovo\Desktop\libmodbus-master\src\win32\modbus.dll" "/VERSION:1.0.0" /INCREMENTAL:NO /NOLOGO ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /MANIFEST "/MANIFESTUAC:level='asInvoker' uiAccess='false'" /manifest:embed /DEBUG "/PDB:C:\Users\Lenovo\Desktop\libmodbus-master\src\win32\modbus.pdb" /MAP /SUBSYSTEM:CONSOLE /TLBID:1 "/IMPLIB:C:\Users\Lenovo\Desktop\libmodbus-master\src\win32\modbus.lib" /MACHINE:X86 /SAFESEH /DLL "C:\Users\Lenovo\Desktop\libmodbus-master\src\win32\/modbus.res"
1>"Debug\modbus-data.obj"
1>"Debug\modbus-rtu.obj"
1>"Debug\modbus-tcp.obj"
1>Debug\modbus.obj
1>**LINK : fatal error LNK1117: option“VERSION:1.0.0”** grammatical error
```
see: 
https://docs.microsoft.com/en-us/cpp/build/reference/version-version-information?view=msvc-160