### PR TITLE
libmodbus change needed for lua-libmodbus

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -207,7 +207,7 @@ static int send_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
     return rc;
 }
 
-int modbus_send_raw_msg(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length, int as_response)
+int modbus_send_raw_msg(modbus_t *ctx, uint8_t *req, const uint8_t *raw_req, int raw_req_length, int as_response)
 {
     sft_t sft;
     uint8_t req[MAX_MESSAGE_LENGTH];

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -249,12 +249,12 @@ int modbus_send_raw_msg(modbus_t *ctx, const uint8_t *raw_req, int raw_req_lengt
 
 int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length)
 {
-    return modbus_send_raw_msg(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length, FALSE);
+    return modbus_send_raw_msg(ctx, raw_req, raw_req_length, FALSE);
 }
 
 int modbus_send_raw_response(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length)
 {
-    return modbus_send_raw_msg(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length, TRUE);
+    return modbus_send_raw_msg(ctx, raw_req, raw_req_length, TRUE);
 }
 
 /*

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -261,7 +261,7 @@ int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_req
         return -1;
     }
 
-    sft.t_id = ctx->backend->prepare_response_tid(req, &req_length)
+    sft.t_id = ctx->backend->prepare_response_tid(req, &req_length);
     sft.slave = raw_req[0];
     sft.function = raw_req[1];
 

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -249,12 +249,13 @@ int modbus_send_raw_msg(modbus_t *ctx, const uint8_t *raw_req, int raw_req_lengt
 
 int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length)
 {
-    return modbus_send_raw_msg(ctx, raw_req, raw_req_length, FALSE);
+    uint8_t *req;
+    return modbus_send_raw_msg(ctx, req, raw_req, raw_req_length, FALSE);
 }
 
-int modbus_send_raw_response(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length)
+int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_resp, int raw_resp_length)
 {
-    return modbus_send_raw_msg(ctx, raw_req, raw_req_length, TRUE);
+    return modbus_send_raw_msg(ctx, req, raw_resp, raw_resp_length, TRUE);
 }
 
 /*

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -246,6 +246,7 @@ int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_res
 {
     sft_t sft;
     uint8_t resp[MAX_MESSAGE_LENGTH];
+    int resp_length;
     int req_length;
 
     if (ctx == NULL) {

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -245,7 +245,6 @@ int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_l
 int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_req, int raw_req_length)
 {
     sft_t sft;
-    uint8_t req[MAX_MESSAGE_LENGTH];
     int req_length;
 
     if (ctx == NULL) {

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -207,7 +207,7 @@ static int send_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
     return rc;
 }
 
-int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length)
+int modbus_send_raw_msg(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length, int as_response)
 {
     sft_t sft;
     uint8_t req[MAX_MESSAGE_LENGTH];
@@ -228,8 +228,13 @@ int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_l
 
     sft.slave = raw_req[0];
     sft.function = raw_req[1];
-    /* The t_id is left to zero */
-    sft.t_id = 0;
+
+    if (as_response) {
+        sft.t_id = ctx->backend->prepare_response_tid(req, &req_length);
+    }else {
+        /* The t_id is left to zero */
+        sft.t_id = 0;
+    }
     /* This response function only set the header so it's convenient here */
     req_length = ctx->backend->build_response_basis(&sft, req);
 
@@ -240,6 +245,16 @@ int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_l
     }
 
     return send_msg(ctx, req, req_length);
+}
+
+int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length)
+{
+    return modbus_send_raw_msg(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length, FALSE);
+}
+
+int modbus_send_raw_response(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length)
+{
+    return modbus_send_raw_msg(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length, TRUE);
 }
 
 /*

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -229,7 +229,7 @@ MODBUS_API void modbus_mapping_free(modbus_mapping_t *mb_mapping);
 
 MODBUS_API int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length);
 
-MODBUS_API int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_resp, int raw_resp_length)
+MODBUS_API int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_resp, int raw_resp_length);
 
 MODBUS_API int modbus_receive(modbus_t *ctx, uint8_t *req);
 

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -229,7 +229,7 @@ MODBUS_API void modbus_mapping_free(modbus_mapping_t *mb_mapping);
 
 MODBUS_API int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length);
 
-MODBUS_API int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_req, int raw_req_length);
+MODBUS_API int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_resp, int raw_resp_length)
 
 MODBUS_API int modbus_receive(modbus_t *ctx, uint8_t *req);
 

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -229,6 +229,8 @@ MODBUS_API void modbus_mapping_free(modbus_mapping_t *mb_mapping);
 
 MODBUS_API int modbus_send_raw_request(modbus_t *ctx, const uint8_t *raw_req, int raw_req_length);
 
+MODBUS_API int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_req, int raw_req_length);
+
 MODBUS_API int modbus_receive(modbus_t *ctx, uint8_t *req);
 
 MODBUS_API int modbus_receive_confirmation(modbus_t *ctx, uint8_t *rsp);


### PR DESCRIPTION
Hello stephane,

we need a additionally function in the libmodbus for lua-libmodbus.
Can you add this in the origin code from you ?

https://github.com/woodsnake/libmodbus/blob/libmodbus-3.1.7.a/src/modbus.c

at Linie 245
```
int modbus_send_raw_response(modbus_t *ctx, uint8_t *req, const uint8_t *raw_resp, int raw_resp_length)
{
    sft_t sft;
    uint8_t resp[MAX_MESSAGE_LENGTH];
    int resp_length;
    int req_length;

    if (ctx == NULL) {
        errno = EINVAL;
        return -1;
    }

    if (raw_resp_length < 2 || raw_resp_length > (MODBUS_MAX_PDU_LENGTH + 1)) {
        /* The raw request must contain function and slave at least and
           must not be longer than the maximum pdu length plus the slave
           address. */
        errno = EINVAL;
        return -1;
    }

    sft.t_id = ctx->backend->prepare_response_tid(req, &req_length);
    sft.slave = raw_resp[0];
    sft.function = raw_resp[1];

    /* This response function only set the header so it's convenient here */
    resp_length = ctx->backend->build_response_basis(&sft, resp);

    if (raw_resp_length > 2) {
        /* Copy data after function code */
        memcpy(resp + resp_length, raw_resp + 2, raw_resp_length - 2);
        resp_length += raw_resp_length - 2;
    }

    return send_msg(ctx, resp, resp_length);
}
```

Thanks