### PR TITLE
Fixed MODBUS_ERROR_RECOVERY_LINK not working on Windows.

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1447,7 +1447,7 @@ int modbus_mask_write_register(modbus_t *ctx, int addr, uint16_t and_mask, uint1
     int rc;
     int req_length;
     /* The request length can not exceed _MIN_REQ_LENGTH - 2 and 4 bytes to
-     * store the masks. The ugly subtraction is there to remove the 'nb' value
+     * store the masks. The ugly substraction is there to remove the 'nb' value
      * (2 bytes) which is not used. */
     uint8_t req[_MIN_REQ_LENGTH + 2];
 

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -182,8 +182,7 @@ static int send_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
         rc = ctx->backend->send(ctx, msg, msg_length);
         if (rc == -1) {
             _error_print(ctx, NULL);
-            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK &&
-                ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_TCP) {
+            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) {
 #ifdef _WIN32
                 const int wsa_err = WSAGetLastError();
                 if (wsa_err == WSAENETRESET || wsa_err == WSAENOTCONN || wsa_err == WSAENOTSOCK ||
@@ -404,8 +403,7 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
         rc = ctx->backend->select(ctx, &rset, p_tv, length_to_read);
         if (rc == -1) {
             _error_print(ctx, "select");
-            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK &&
-                ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_TCP) {
+            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) {
 #ifdef _WIN32
                 wsa_err = WSAGetLastError();
 


### PR DESCRIPTION
Fixes issue #643

Otherwise, I don't like how error recovery is coded : if we want to break the loop (e.g. to close the program), we need to disable the error recovery from another thread but it is not a good idea to use the context on many threads. It is best to use a finite number of attempts to ensure that the function does not loop indefinitely. Or just remove the do-while loop !