### PR TITLE
Fix doc links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Ethernet TCP) called backends in *libmodbus*.
 
 The first step is to allocate and set a `modbus_t` context according to the
 required backend (RTU or TCP) with a dedicated function, such as
-[modbus_new_rtu](modbus_new_rtu).
+[modbus_new_rtu](modbus_new_rtu.md).
 The function will return an opaque structure called `modbus_t` containing all
 necessary information to establish a connection with other Modbus devices
 according to the selected backend.
@@ -69,7 +69,7 @@ always initiated by the master.
 
 Many Modbus devices can be connected together on the same physical link so
 before sending a message, you must set the slave (receiver) with
-[modbus_set_slave](mobus_set_slave). If you're running a slave, its slave number
+[modbus_set_slave](modbus_set_slave.md). If you're running a slave, its slave number
 will be used to filter received messages.
 
 The libmodbus implementation of RTU isn't time based as stated in original
@@ -80,17 +80,17 @@ must take care to set a response timeout of slaves less than response timeout of
 master (ortherwise other slaves may ignore master requests when one of the slave
 is not responding).
 
-To create a Modbus RTU context, you should use [modbus_new_rtu](modbus_new_rtu).
+To create a Modbus RTU context, you should use [modbus_new_rtu](modbus_new_rtu.md).
 
 You can tweak the serial mode with the following functions:
 
-- [modbus_rtu_get_serial_mode](modbus_rtu_get_serial_mode)
-- [modbus_rtu_set_serial_mode](modbus_rtu_set_serial_mode)
-- [modbus_rtu_get_rts](modbus_rtu_get_rts)
-- [modbus_rtu_set_rts](modbus_rtu_set_rts)
-- [modbus_rtu_set_custom_rts](modbus_rtu_set_custom_rts)
-- [modbus_rtu_get_rts_delay](modbus_rtu_get_rts_delay)
-- [modbus_rtu_set_rts_delay](modbus_rtu_set_rts_delay)
+- [modbus_rtu_get_serial_mode](modbus_rtu_get_serial_mode.md)
+- [modbus_rtu_set_serial_mode](modbus_rtu_set_serial_mode.md)
+- [modbus_rtu_get_rts](modbus_rtu_get_rts.md)
+- [modbus_rtu_set_rts](modbus_rtu_set_rts.md)
+- [modbus_rtu_set_custom_rts](modbus_rtu_set_custom_rts.md)
+- [modbus_rtu_get_rts_delay](modbus_rtu_get_rts_delay.md)
+- [modbus_rtu_set_rts_delay](modbus_rtu_set_rts_delay.md)
 
 ### TCP (IPv4) Context
 
@@ -98,7 +98,7 @@ The TCP backend implements a Modbus variant used for communications over
 TCP/IPv4 networks. It does not require a checksum calculation as lower layer
 takes care of the same.
 
-To create a Modbus TCP context, you should use [modbus_new_tcp](modbus_new_tcp).
+To create a Modbus TCP context, you should use [modbus_new_tcp](modbus_new_tcp.md).
 
 ### TCP PI (IPv4 and IPv6) Context
 
@@ -109,25 +109,25 @@ calculation as lower layer takes care of the same.
 Contrary to the TCP IPv4 only backend, the TCP PI backend offers hostname
 resolution but it consumes about 1Kb of additional memory.
 
-Create a Modbus TCP PI context, you should use [modbus_new_tcp_pi](modbus_new_tcp_pi).
+Create a Modbus TCP PI context, you should use [modbus_new_tcp_pi](modbus_new_tcp_pi.md).
 
 ## Connection
 
 The following functions are provided to establish and close a connection with
 Modbus devices:
 
-- [modbus_connect](modbus_connect) establishes a connection.
-- [modbus_close](modbus_close) closes a connection.
-- [modbus_flush](modbus_flush) flushed a connection.
+- [modbus_connect](modbus_connect.md) establishes a connection.
+- [modbus_close](modbus_close.md) closes a connection.
+- [modbus_flush](modbus_flush.md) flushed a connection.
 
 In RTU, you should define the slave ID of your client with
-[modbus_set_slave](modbus_set_slave).
+[modbus_set_slave](modbus_set_slave.md).
 
 To analyse the exchanged data, you can enable the debug mode with
-[modbus_set_debug](modbus_set_debug).
+[modbus_set_debug](modbus_set_debug.md).
 
 Once you have completed the communication or at the end of your program, you
-should free the resources with the common function, [modbus_free](modbus_free)
+should free the resources with the common function, [modbus_free](modbus_free.md)
 
 ## Reads and writes from the client
 
@@ -137,31 +137,31 @@ send Modbus requests:
 
 To read data:
 
-- [modbus_read_bits](modbus_read_bits)
-- [modbus_read_input_bits](modbus_read_input_bits)
-- [modbus_read_registers](modbus_read_registers)
-- [modbus_read_input_registers](modbus_read_input_registers)
-- [modbus_report_slave_id](modbus_report_slave_id)
+- [modbus_read_bits](modbus_read_bits.md)
+- [modbus_read_input_bits](modbus_read_input_bits.md)
+- [modbus_read_registers](modbus_read_registers.md)
+- [modbus_read_input_registers](modbus_read_input_registers.md)
+- [modbus_report_slave_id](modbus_report_slave_id.md)
 
 To write data:
 
-- [modbus_write_bit](modbus_write_bit)
-- [modbus_write_register](modbus_write_register)
-- [modbus_write_bits](modbus_write_bits)
-- [modbus_write_registers](modbus_write_registers)
+- [modbus_write_bit](modbus_write_bit.md)
+- [modbus_write_register](modbus_write_register.md)
+- [modbus_write_bits](modbus_write_bits.md)
+- [modbus_write_registers](modbus_write_registers.md)
 
 To write and read data in a single operation:
 
-- [modbus_write_and_read_registers](modbus_write_and_read_registers)
+- [modbus_write_and_read_registers](modbus_write_and_read_registers.md)
 
 To send and receive low-level requests:
 
-- [modbus_send_raw_request](modbus_send_raw_request)
-- [modbus_receive_confirmation](modbus_receive_confirmation)
+- [modbus_send_raw_request](modbus_send_raw_request.md)
+- [modbus_receive_confirmation](modbus_receive_confirmation.md)
 
 To reply to an exception:
 
-- [modbus_reply_exception](modbus_reply_exception)
+- [modbus_reply_exception](modbus_reply_exception.md)
 
 ## Handling requests from server
 
@@ -171,39 +171,39 @@ handle requests:
 
 Data mapping:
 
-- [modbus_mapping_new](modbus_mapping_new)
-- [modbus_mapping_free](modbus_mapping_free)
+- [modbus_mapping_new](modbus_mapping_new.md)
+- [modbus_mapping_free](modbus_mapping_free.md)
 
 Receive:
 
-- [modbus_receive](modbus_receive)
+- [modbus_receive](modbus_receive.md)
 
 Reply:
 
-- [modbus_reply](modbus_reply)
-- [modbus_reply_exception](modbus_reply_exception)
+- [modbus_reply](modbus_reply.md)
+- [modbus_reply_exception](modbus_reply_exception.md)
 
 ## Advanced functions
 
 Timeout settings:
 
-- [modbus_get_byte_timeout](modbus_get_byte_timeout)
-- [modbus_set_byte_timeout](modbus_set_byte_timeout)
-- [modbus_get_response_timeout](modbus_get_response_timeout)
-- [modbus_set_response_timeout](modbus_set_response_timeout)
+- [modbus_get_byte_timeout](modbus_get_byte_timeout.md)
+- [modbus_set_byte_timeout](modbus_set_byte_timeout.md)
+- [modbus_get_response_timeout](modbus_get_response_timeout.md)
+- [modbus_set_response_timeout](modbus_set_response_timeout.md)
 
 Error recovery mode:
 
-- [modbus_set_error_recovery](modbus_set_error_recovery)
+- [modbus_set_error_recovery](modbus_set_error_recovery.md)
 
 Setter/getter of internal socket:
 
-- [modbus_set_socket](modbus_set_socket)
-- [modbus_get_socket](modbus_get_socket)
+- [modbus_set_socket](modbus_set_socket.md)
+- [modbus_get_socket](modbus_get_socket.md)
 
 Information about header:
 
-- [modbus_get_header_length](modbus_get_header_length)
+- [modbus_get_header_length](modbus_get_header_length.md)
 
 ## Data handling
 
@@ -220,22 +220,22 @@ Macros for data manipulation:
 
 Handling of bits and bytes:
 
-- [modbus_set_bits_from_byte](modbus_set_bits_from_byte)
-- [modbus_set_bits_from_bytes](modbus_set_bits_from_bytes)
-- [modbus_get_byte_from_bits](modbus_get_byte_from_bits)
+- [modbus_set_bits_from_byte](modbus_set_bits_from_byte.md)
+- [modbus_set_bits_from_bytes](modbus_set_bits_from_bytes.md)
+- [modbus_get_byte_from_bits](modbus_get_byte_from_bits.md)
 
 Set or get float numbers:
 
-- [modbus_get_float_abcd](modbus_get_float_abcd)
-- [modbus_set_float_abcd](modbus_set_float_abcd)
-- [modbus_get_float_badc](modbus_get_float_badc)
-- [modbus_set_float_badc](modbus_set_float_badc)
-- [modbus_get_float_cdab](modbus_get_float_cdab)
-- [modbus_set_float_cdab](modbus_set_float_cdab)
-- [modbus_get_float_dcba](modbus_get_float_dcba)
-- [modbus_set_float_dcba](modbus_set_float_dcba)
-- [modbus_get_float](modbus_get_float) **deprecated**
-- [modbus_set_float](modbus_set_float) **deprecated**
+- [modbus_get_float_abcd](modbus_get_float_abcd.md)
+- [modbus_set_float_abcd](modbus_set_float_abcd.md)
+- [modbus_get_float_badc](modbus_get_float_badc.md)
+- [modbus_set_float_badc](modbus_set_float_badc.md)
+- [modbus_get_float_cdab](modbus_get_float_cdab.md)
+- [modbus_set_float_cdab](modbus_set_float_cdab.md)
+- [modbus_get_float_dcba](modbus_get_float_dcba.md)
+- [modbus_set_float_dcba](modbus_set_float_dcba.md)
+- [modbus_get_float](modbus_get_float.md) **deprecated**
+- [modbus_set_float](modbus_set_float.md) **deprecated**
 
 ## Error handling
 
@@ -247,7 +247,7 @@ shall return either a NULL value (if returning a pointer) or a negative value
 
 The *modbus_strerror()* function is provided to translate libmodbus-specific
 error codes into error message strings; for details refer to
-[modbus_strerror](modbus_strerror).
+[modbus_strerror](modbus_strerror.md).
 
 ## Miscellaneous
 

--- a/docs/modbus_close.md
+++ b/docs/modbus_close.md
@@ -37,4 +37,4 @@ modbus_free(ctx);
 
 ## See also
 
-- [modbus_connect](modbus_connect)
+- [modbus_connect](modbus_connect.md)

--- a/docs/modbus_connect.md
+++ b/docs/modbus_connect.md
@@ -37,4 +37,4 @@ if (modbus_connect(ctx) == -1) {
 
 ## See also
 
-- [modbus_close](modbus_close)
+- [modbus_close](modbus_close.md)

--- a/docs/modbus_get_byte_from_bits.md
+++ b/docs/modbus_get_byte_from_bits.md
@@ -22,5 +22,5 @@ The function shall return a byte containing the bits read.
 
 ## See also
 
-- [modbus_set_bits_from_byte](modbus_set_bits_from_byte)
-- [modbus_set_bits_from_bytes](modbus_set_bits_from_bytes)
+- [modbus_set_bits_from_byte](modbus_set_bits_from_byte.md)
+- [modbus_set_bits_from_bytes](modbus_set_bits_from_bytes.md)

--- a/docs/modbus_get_byte_timeout.md
+++ b/docs/modbus_get_byte_timeout.md
@@ -33,6 +33,6 @@ modbus_get_byte_timeout(ctx, &to_sec, &to_usec);
 
 ## See also
 
-- [modbus_set_byte_timeout](modbus_set_byte_timeout)
-- [modbus_get_response_timeout](modbus_get_response_timeout)
-- [modbus_set_response_timeout](modbus_set_response_timeout)
+- [modbus_set_byte_timeout](modbus_set_byte_timeout.md)
+- [modbus_get_response_timeout](modbus_get_response_timeout.md)
+- [modbus_set_response_timeout](modbus_set_response_timeout.md)

--- a/docs/modbus_get_float.md
+++ b/docs/modbus_get_float.md
@@ -26,6 +26,6 @@ The function shall return a float.
 
 ## See also
 
-- [modbus_set_float](modbus_set_float)
-- [modbus_set_float_dcba](modbus_set_float_dcba)
-- [modbus_get_float_dcba](modbus_get_float_dcba)
+- [modbus_set_float](modbus_set_float.md)
+- [modbus_set_float_dcba](modbus_set_float_dcba.md)
+- [modbus_get_float_dcba](modbus_get_float_dcba.md)

--- a/docs/modbus_get_float_abcd.md
+++ b/docs/modbus_get_float_abcd.md
@@ -23,7 +23,7 @@ The function shall return a float.
 
 ## See also
 
-- [modbus_set_float_abcd](modbus_set_float_abcd)
-- [modbus_get_float_badc](modbus_get_float_badc)
-- [modbus_get_float_cdab](modbus_get_float_cdab)
-- [modbus_get_float_dcba](modbus_get_float_dcba)
+- [modbus_set_float_abcd](modbus_set_float_abcd.md)
+- [modbus_get_float_badc](modbus_get_float_badc.md)
+- [modbus_get_float_cdab](modbus_get_float_cdab.md)
+- [modbus_get_float_dcba](modbus_get_float_dcba.md)

--- a/docs/modbus_get_float_badc.md
+++ b/docs/modbus_get_float_badc.md
@@ -23,7 +23,7 @@ The function shall return a float.
 
 ## See also
 
-- [modbus_set_float_badc](modbus_set_float_badc)
-- [modbus_get_float_abcd](modbus_get_float_abcd)
-- [modbus_get_float_cdab](modbus_get_float_cdab)
-- [modbus_get_float_dcba](modbus_get_float_dcba)
+- [modbus_set_float_badc](modbus_set_float_badc.md)
+- [modbus_get_float_abcd](modbus_get_float_abcd.md)
+- [modbus_get_float_cdab](modbus_get_float_cdab.md)
+- [modbus_get_float_dcba](modbus_get_float_dcba.md)

--- a/docs/modbus_get_float_cdab.md
+++ b/docs/modbus_get_float_cdab.md
@@ -23,7 +23,7 @@ The function shall return a float.
 
 ## See also
 
-- [modbus_set_float_cdab](modbus_set_float_cdab)
-- [modbus_get_float_abcd](modbus_get_float_abcd)
-- [modbus_get_float_badc](modbus_get_float_badc)
-- [modbus_get_float_dcba](modbus_get_float_dcba)
+- [modbus_set_float_cdab](modbus_set_float_cdab.md)
+- [modbus_get_float_abcd](modbus_get_float_abcd.md)
+- [modbus_get_float_badc](modbus_get_float_badc.md)
+- [modbus_get_float_dcba](modbus_get_float_dcba.md)

--- a/docs/modbus_get_float_dcba.md
+++ b/docs/modbus_get_float_dcba.md
@@ -23,7 +23,7 @@ The function shall return a float.
 
 ## See also
 
-- [modbus_set_float_dcba](modbus_set_float_dcba)
-- [modbus_get_float_abcd](modbus_get_float_abcd)
-- [modbus_get_float_badc](modbus_get_float_badc)
-- [modbus_get_float_cdab](modbus_get_float_cdab)
+- [modbus_set_float_dcba](modbus_set_float_dcba.md)
+- [modbus_get_float_abcd](modbus_get_float_abcd.md)
+- [modbus_get_float_badc](modbus_get_float_badc.md)
+- [modbus_get_float_cdab](modbus_get_float_cdab.md)

--- a/docs/modbus_get_indication_timeout.md
+++ b/docs/modbus_get_indication_timeout.md
@@ -34,6 +34,6 @@ modbus_get_indication_timeout(ctx, &to_sec, &to_usec);
 
 ## See also
 
-- [modbus_set_indication_timeout](modbus_set_indication_timeout)
-- [modbus_get_response_timeout](modbus_get_response_timeout)
-- [modbus_set_response_timeout](modbus_set_response_timeout)
+- [modbus_set_indication_timeout](modbus_set_indication_timeout.md)
+- [modbus_get_response_timeout](modbus_get_response_timeout.md)
+- [modbus_set_response_timeout](modbus_set_response_timeout.md)

--- a/docs/modbus_get_response_timeout.md
+++ b/docs/modbus_get_response_timeout.md
@@ -35,6 +35,6 @@ modbus_set_response_timeout(ctx, 0, 0);
 
 ## See also
 
-- [modbus_set_response_timeout](modbus_set_response_timeout)
-- [modbus_get_byte_timeout](modbus_get_byte_timeout)
-- [modbus_set_byte_timeout](modbus_set_byte_timeout)
+- [modbus_set_response_timeout](modbus_set_response_timeout.md)
+- [modbus_get_byte_timeout](modbus_get_byte_timeout.md)
+- [modbus_set_byte_timeout](modbus_set_byte_timeout.md)

--- a/docs/modbus_get_slave.md
+++ b/docs/modbus_get_slave.md
@@ -26,4 +26,4 @@ return -1 and set errno to one of the values defined below.
 
 ## See also
 
-- [modbus_set_slave](modbus_set_slave)
+- [modbus_set_slave](modbus_set_slave.md)

--- a/docs/modbus_get_socket.md
+++ b/docs/modbus_get_socket.md
@@ -22,4 +22,4 @@ successful. Otherwise it shall return -1 and set errno.
 
 ## See also
 
-- [modbus_set_socket](modbus_set_socket)
+- [modbus_set_socket](modbus_set_socket.md)

--- a/docs/modbus_mapping_free.md
+++ b/docs/modbus_mapping_free.md
@@ -21,4 +21,4 @@ There is no return values.
 
 ## See also
 
-- [modbus_mapping_new](modbus_mapping_new)
+- [modbus_mapping_new](modbus_mapping_new.md)

--- a/docs/modbus_mapping_new.md
+++ b/docs/modbus_mapping_new.md
@@ -17,7 +17,7 @@ input bits, registers and inputs registers. The pointers are stored in
 modbus_mapping_t structure. All values of the arrays are initialized to zero.
 
 This function is equivalent to a call of the
-[modbus_mapping_new_start_address](modbus_mapping_new_start_address) function
+[modbus_mapping_new_start_address](modbus_mapping_new_start_address.md) function
 with all start addresses to `0`.
 
 If it isn't necessary to allocate an array for a specific type of data, you can
@@ -56,5 +56,5 @@ if (mb_mapping == NULL) {
 
 ## See also
 
-- [modbus_mapping_free](modbus_mapping_free)
-- [modbus_mapping_new_start_address](modbus_mapping_new_start_address)
+- [modbus_mapping_free](modbus_mapping_free.md)
+- [modbus_mapping_new_start_address](modbus_mapping_new_start_address.md)

--- a/docs/modbus_mapping_new_start_address.md
+++ b/docs/modbus_mapping_new_start_address.md
@@ -81,5 +81,5 @@ if (mb_mapping == NULL) {
 
 ## See also
 
-- [modbus_mapping_new](modbus_mapping_new)
-- [modbus_mapping_free](modbus_mapping_free)
+- [modbus_mapping_new](modbus_mapping_new.md)
+- [modbus_mapping_free](modbus_mapping_free.md)

--- a/docs/modbus_mask_write_register.md
+++ b/docs/modbus_mask_write_register.md
@@ -26,5 +26,5 @@ errno.
 
 ## See also
 
-- [modbus_read_registers](modbus_read_registers)
-- [modbus_write_registers](modbus_write_registers)
+- [modbus_read_registers](modbus_read_registers.md)
+- [modbus_write_registers](modbus_write_registers.md)

--- a/docs/modbus_new_rtu.md
+++ b/docs/modbus_new_rtu.md
@@ -36,8 +36,8 @@ The `stop_bits` argument specifies the bits of stop, the allowed values are 1
 and 2.
 
 Once the `modbus_t` structure is initialized, you must set the slave of your
-device with [modbus_set_slave](modbus_set_slave) and connect to the serial bus with
-[modbus_connect](modbus_connect).
+device with [modbus_set_slave](modbus_set_slave.md) and connect to the serial bus with
+[modbus_connect](modbus_connect.md).
 
 ## Return value
 
@@ -73,5 +73,5 @@ if (modbus_connect(ctx) == -1) {
 
 ## See also
 
-- [modbus_new_tcp](modbus_new_tcp)
-- [modbus_free](modbus_free)
+- [modbus_new_tcp](modbus_new_tcp.md)
+- [modbus_free](modbus_free.md)

--- a/docs/modbus_new_tcp.md
+++ b/docs/modbus_new_tcp.md
@@ -56,5 +56,5 @@ if (modbus_connect(ctx) == -1) {
 
 ## See also
 
-- [modbus_tcp_listen](modbus_tcp_listen)
-- [modbus_free](modbus_free)
+- [modbus_tcp_listen](modbus_tcp_listen.md)
+- [modbus_free](modbus_free.md)

--- a/docs/modbus_new_tcp_pi.md
+++ b/docs/modbus_new_tcp_pi.md
@@ -57,6 +57,6 @@ if (modbus_connect(ctx) == -1) {
 
 ## See also
 
-- [modbus_new_tcp](modbus_new_tcp)
-- [modbus_tcp_pi_listen](modbus_tcp_pi_listen)
-- [modbus_free](modbus_free)
+- [modbus_new_tcp](modbus_new_tcp.md)
+- [modbus_tcp_pi_listen](modbus_tcp_pi_listen.md)
+- [modbus_free](modbus_free.md)

--- a/docs/modbus_read_bits.md
+++ b/docs/modbus_read_bits.md
@@ -32,5 +32,5 @@ shall return -1 and set errno.
 
 ## See also
 
-- [modbus_write_bit](modbus_write_bit)
-- [modbus_write_bits](modbus_write_bits)
+- [modbus_write_bit](modbus_write_bit.md)
+- [modbus_write_bits](modbus_write_bits.md)

--- a/docs/modbus_read_input_bits.md
+++ b/docs/modbus_read_input_bits.md
@@ -32,4 +32,4 @@ successful. Otherwise it shall return -1 and set errno.
 
 ## See also
 
-- [modbus_read_input_registers](modbus_read_input_registers)
+- [modbus_read_input_registers](modbus_read_input_registers.md)

--- a/docs/modbus_read_input_registers.md
+++ b/docs/modbus_read_input_registers.md
@@ -34,6 +34,6 @@ successful. Otherwise it shall return -1 and set errno.
 
 ## See also
 
-- [modbus_read_input_bits](modbus_read_input_bits)
-- [modbus_write_register](modbus_write_register)
-- [modbus_write_registers](modbus_write_registers)
+- [modbus_read_input_bits](modbus_read_input_bits.md)
+- [modbus_write_register](modbus_write_register.md)
+- [modbus_write_registers](modbus_write_registers.md)

--- a/docs/modbus_read_registers.md
+++ b/docs/modbus_read_registers.md
@@ -61,5 +61,5 @@ modbus_free(ctx);
 
 ## See also
 
-- [modbus_write_register](modbus_write_register)
-- [modbus_write_registers](modbus_write_registers)
+- [modbus_write_register](modbus_write_register.md)
+- [modbus_write_registers](modbus_write_registers.md)

--- a/docs/modbus_receive.md
+++ b/docs/modbus_receive.md
@@ -17,7 +17,7 @@ socket of the context `ctx`. This function is used by Modbus slave/server to
 receive and analyze indication request sent by the masters/clients.
 
 If you need to use another socket or file descriptor than the one defined in the
-context `ctx`, see the function [modbus_set_socket](modbus_set_socket).
+context `ctx`, see the function [modbus_set_socket](modbus_set_socket.md).
 
 ## Return value
 
@@ -28,5 +28,5 @@ shall return -1 and set errno.
 
 ## See also
 
-- [modbus_set_socket](modbus_set_socket)
-- [modbus_reply](modbus_reply)
+- [modbus_set_socket](modbus_set_socket.md)
+- [modbus_reply](modbus_reply.md)

--- a/docs/modbus_receive_confirmation.md
+++ b/docs/modbus_receive_confirmation.md
@@ -40,4 +40,4 @@ rc = modbus_receive_confirmation(ctx, rsp);
 
 ## See also
 
-- [modbus_send_raw_request](modbus_send_raw_request)
+- [modbus_send_raw_request](modbus_send_raw_request.md)

--- a/docs/modbus_reply.md
+++ b/docs/modbus_reply.md
@@ -36,4 +36,4 @@ See also the errors returned by the syscall used to send the response (eg. send 
 
 ## See also
 
-- [modbus_reply_exception](modbus_reply_exception)
+- [modbus_reply_exception](modbus_reply_exception.md)

--- a/docs/modbus_reply_exception.md
+++ b/docs/modbus_reply_exception.md
@@ -42,4 +42,4 @@ successful. Otherwise it shall return -1 and set errno.
 
 ## See also
 
-- [modbus_reply](modbus_reply)
+- [modbus_reply](modbus_reply.md)

--- a/docs/modbus_rtu_get_rts.md
+++ b/docs/modbus_rtu_get_rts.md
@@ -32,4 +32,4 @@ return -1 and set errno.
 
 ## See also
 
-- [modbus_rtu_set_rts](modbus_rtu_set_rts)
+- [modbus_rtu_set_rts](modbus_rtu_set_rts.md)

--- a/docs/modbus_rtu_get_rts_delay.md
+++ b/docs/modbus_rtu_get_rts_delay.md
@@ -28,4 +28,4 @@ microseconds if successful. Otherwise it shall return -1 and set errno.
 
 ## See also
 
-- [modbus_rtu_set_rts_delay](modbus_rtu_set_rts_delay)
+- [modbus_rtu_set_rts_delay](modbus_rtu_set_rts_delay.md)

--- a/docs/modbus_rtu_set_rts.md
+++ b/docs/modbus_rtu_set_rts.md
@@ -66,4 +66,4 @@ modbus_free(ctx);
 
 ## See also
 
-- [modbus_rtu_get_rts](modbus_rtu_get_rts)
+- [modbus_rtu_get_rts](modbus_rtu_get_rts.md)

--- a/docs/modbus_rtu_set_rts_delay.md
+++ b/docs/modbus_rtu_set_rts_delay.md
@@ -28,4 +28,4 @@ Otherwise it shall return -1 and set errno.
 
 ## See also
 
-- [modbus_rtu_get_rts_delay](modbus_rtu_get_rts_delay)
+- [modbus_rtu_get_rts_delay](modbus_rtu_get_rts_delay.md)

--- a/docs/modbus_send_raw_request.md
+++ b/docs/modbus_send_raw_request.md
@@ -54,4 +54,4 @@ modbus_free(ctx);
 
 ## See also
 
-- [modbus_receive_confirmation](modbus_receive_confirmation)
+- [modbus_receive_confirmation](modbus_receive_confirmation.md)

--- a/docs/modbus_set_bits_from_byte.md
+++ b/docs/modbus_set_bits_from_byte.md
@@ -23,5 +23,5 @@ There is no return values.
 
 ## See also
 
-- [modbus_set_bits_from_byte](modbus_set_bits_from_byte)
-- [modbus_set_bits_from_bytes](modbus_set_bits_from_bytes)
+- [modbus_set_bits_from_byte](modbus_set_bits_from_byte.md)
+- [modbus_set_bits_from_bytes](modbus_set_bits_from_bytes.md)

--- a/docs/modbus_set_bits_from_bytes.md
+++ b/docs/modbus_set_bits_from_bytes.md
@@ -22,5 +22,5 @@ There is no return values.
 
 ## See also
 
-- [modbus_set_bits_from_byte](modbus_set_bits_from_byte)
-- [modbus_get_byte_from_bits](modbus_get_byte_from_bits)
+- [modbus_set_bits_from_byte](modbus_set_bits_from_byte.md)
+- [modbus_get_byte_from_bits](modbus_get_byte_from_bits.md)

--- a/docs/modbus_set_byte_timeout.md
+++ b/docs/modbus_set_byte_timeout.md
@@ -37,7 +37,7 @@ errno.
 
 ## See also
 
-- [modbus_get_byte_timeout](modbus_get_byte_timeout)
-- [modbus_get_response_timeout](modbus_get_response_timeout)
-- [modbus_set_response_timeout](modbus_set_response_timeout)
+- [modbus_get_byte_timeout](modbus_get_byte_timeout.md)
+- [modbus_get_response_timeout](modbus_get_response_timeout.md)
+- [modbus_set_response_timeout](modbus_set_response_timeout.md)
 w

--- a/docs/modbus_set_float.md
+++ b/docs/modbus_set_float.md
@@ -25,5 +25,5 @@ There is no return values.
 
 ## See also
 
-- [modbus_get_float](modbus_get_float)
-- [modbus_set_float_dcba](modbus_set_float_dcba)
+- [modbus_get_float](modbus_get_float.md)
+- [modbus_set_float_dcba](modbus_set_float_dcba.md)

--- a/docs/modbus_set_float_abcd.md
+++ b/docs/modbus_set_float_abcd.md
@@ -22,7 +22,7 @@ There is no return values.
 
 ## See also
 
-- [modbus_get_float_abcd](modbus_get_float_abcd)
-- [modbus_set_float_badc](modbus_set_float_badc)
-- [modbus_set_float_cdab](modbus_set_float_cdab)
-- [modbus_set_float_dcba](modbus_set_float_dcba)
+- [modbus_get_float_abcd](modbus_get_float_abcd.md)
+- [modbus_set_float_badc](modbus_set_float_badc.md)
+- [modbus_set_float_cdab](modbus_set_float_cdab.md)
+- [modbus_set_float_dcba](modbus_set_float_dcba.md)

--- a/docs/modbus_set_float_badc.md
+++ b/docs/modbus_set_float_badc.md
@@ -22,7 +22,7 @@ There is no return values.
 
 ## See also
 
-- [modbus_get_float_badc](modbus_get_float_badc)
-- [modbus_set_float_abcd](modbus_set_float_abcd)
-- [modbus_set_float_cdab](modbus_set_float_cdab)
-- [modbus_set_float_dcba](modbus_set_float_dcba)
+- [modbus_get_float_badc](modbus_get_float_badc.md)
+- [modbus_set_float_abcd](modbus_set_float_abcd.md)
+- [modbus_set_float_cdab](modbus_set_float_cdab.md)
+- [modbus_set_float_dcba](modbus_set_float_dcba.md)

--- a/docs/modbus_set_float_cdab.md
+++ b/docs/modbus_set_float_cdab.md
@@ -23,7 +23,7 @@ There is no return values.
 
 ## See also
 
-- [modbus_get_float_cdab](modbus_get_float_cdab)
-- [modbus_set_float_abcd](modbus_set_float_abcd)
-- [modbus_set_float_badc](modbus_set_float_badc)
-- [modbus_set_float_dcba](modbus_set_float_dcba)
+- [modbus_get_float_cdab](modbus_get_float_cdab.md)
+- [modbus_set_float_abcd](modbus_set_float_abcd.md)
+- [modbus_set_float_badc](modbus_set_float_badc.md)
+- [modbus_set_float_dcba](modbus_set_float_dcba.md)

--- a/docs/modbus_set_float_dcba.md
+++ b/docs/modbus_set_float_dcba.md
@@ -22,6 +22,6 @@ There is no return values.
 
 ## See also
 
-- [modbus_get_float_dcba](modbus_get_float_dcba)
-- [modbus_set_float](modbus_set_float)
-- [modbus_get_float](modbus_get_float)
+- [modbus_get_float_dcba](modbus_get_float_dcba.md)
+- [modbus_set_float](modbus_set_float.md)
+- [modbus_get_float](modbus_get_float.md)

--- a/docs/modbus_set_indication_timeout.md
+++ b/docs/modbus_set_indication_timeout.md
@@ -31,6 +31,6 @@ errno.
 
 ## See also
 
-- [modbus_get_indication_timeout](modbus_get_indication_timeout)
-- [modbus_get_response_timeout](modbus_get_response_timeout)
-- [modbus_set_response_timeout](modbus_set_response_timeout)
+- [modbus_get_indication_timeout](modbus_get_indication_timeout.md)
+- [modbus_get_response_timeout](modbus_get_response_timeout.md)
+- [modbus_set_response_timeout](modbus_set_response_timeout.md)

--- a/docs/modbus_set_response_timeout.md
+++ b/docs/modbus_set_response_timeout.md
@@ -46,6 +46,6 @@ modbus_set_response_timeout(ctx, 0, 200000);
 
 ## See also
 
-- [modbus_get_response_timeout](modbus_get_response_timeout)
-- [modbus_get_byte_timeout](modbus_get_byte_timeout)
-- [modbus_set_byte_timeout](modbus_set_byte_timeout)
+- [modbus_get_response_timeout](modbus_get_response_timeout.md)
+- [modbus_get_byte_timeout](modbus_get_byte_timeout.md)
+- [modbus_set_byte_timeout](modbus_set_byte_timeout.md)

--- a/docs/modbus_set_slave.md
+++ b/docs/modbus_set_slave.md
@@ -69,4 +69,4 @@ if (modbus_connect(ctx) == -1) {
 
 ## See also
 
-- [modbus_get_slave](modbus_get_slave)
+- [modbus_get_slave](modbus_get_slave.md)

--- a/docs/modbus_set_socket.md
+++ b/docs/modbus_set_socket.md
@@ -42,4 +42,4 @@ if (FD_ISSET(master_socket, &rdset)) {
 
 ## See also
 
-- [modbus_get_socket](modbus_get_socket)
+- [modbus_get_socket](modbus_get_socket.md)

--- a/docs/modbus_tcp_accept.md
+++ b/docs/modbus_tcp_accept.md
@@ -41,6 +41,6 @@ modbus_free(ctx);
 
 ## See also
 
-- [modbus_tcp_pi_accept](modbus_tcp_pi_accept)
-- [modbus_tcp_listen](modbus_tcp_listen)
-- [modbus_tcp_pi_listen](modbus_tcp_pi_listen)
+- [modbus_tcp_pi_accept](modbus_tcp_pi_accept.md)
+- [modbus_tcp_listen](modbus_tcp_listen.md)
+- [modbus_tcp_pi_listen](modbus_tcp_pi_listen.md)

--- a/docs/modbus_tcp_listen.md
+++ b/docs/modbus_tcp_listen.md
@@ -15,7 +15,7 @@ int modbus_tcp_listen(modbus_t *ctx, int nb_connection);
 
 The *modbus_tcp_listen()* function shall create a socket and listen to maximum
 `nb_connection` incoming connections on the specified IP address.  The context
-`ctx` must be allocated and initialized with [modbus_new_tcp](modbus_new_tcp) before to
+`ctx` must be allocated and initialized with [modbus_new_tcp](modbus_new_tcp.md) before to
 set the IP address to listen, if IP address is set to NULL or '0.0.0.0', any addresses will be
 listen.
 
@@ -57,6 +57,6 @@ modbus_free(ctx);
 
 ## See also
 
-- [modbus_new_tcp](modbus_new_tcp)
-- [modbus_tcp_accept](modbus_tcp_accept)
-- [modbus_tcp_pi_listen](modbus_tcp_pi_listen)
+- [modbus_new_tcp](modbus_new_tcp.md)
+- [modbus_tcp_accept](modbus_tcp_accept.md)
+- [modbus_tcp_pi_listen](modbus_tcp_pi_listen.md)

--- a/docs/modbus_tcp_pi_accept.md
+++ b/docs/modbus_tcp_pi_accept.md
@@ -41,6 +41,6 @@ modbus_free(ctx);
 
 ## See also
 
-- [modbus_tcp_pi_accept](modbus_tcp_pi_accept)
-- [modbus_tcp_listen](modbus_tcp_listen)
-- [modbus_tcp_pi_listen](modbus_tcp_pi_listen)
+- [modbus_tcp_pi_accept](modbus_tcp_pi_accept.md)
+- [modbus_tcp_listen](modbus_tcp_listen.md)
+- [modbus_tcp_pi_listen](modbus_tcp_pi_listen.md)

--- a/docs/modbus_tcp_pi_listen.md
+++ b/docs/modbus_tcp_pi_listen.md
@@ -14,7 +14,7 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection);
 
 The *modbus_tcp_pi_listen()* function shall create a socket and listen to
 maximum `nb_connection` incoming connections on the specified nodes.  The
-context *ctx* must be allocated and initialized with [modbus_new_tcp_pi](modbus_new_tcp_pi)
+context *ctx* must be allocated and initialized with [modbus_new_tcp_pi](modbus_new_tcp_pi.md)
 before to set the node to listen, if node is set to NULL or '0.0.0.0', any addresses will be
 listen.
 
@@ -50,6 +50,6 @@ modbus_free(ctx);
 
 ## See also
 
-- [modbus_new_tcp_pi](modbus_new_tcp_pi)
-- [modbus_tcp_pi_accept](modbus_tcp_pi_accept)
-- [modbus_tcp_listen](modbus_tcp_listen)
+- [modbus_new_tcp_pi](modbus_new_tcp_pi.md)
+- [modbus_tcp_pi_accept](modbus_tcp_pi_accept.md)
+- [modbus_tcp_listen](modbus_tcp_listen.md)

--- a/docs/modbus_write_and_read_registers.md
+++ b/docs/modbus_write_and_read_registers.md
@@ -38,6 +38,6 @@ it shall return -1 and set errno.
 
 ## See also
 
-- [modbus_read_registers](modbus_read_registers)
-- [modbus_write_register](modbus_write_register)
-- [modbus_write_registers](modbus_write_registers)
+- [modbus_read_registers](modbus_read_registers.md)
+- [modbus_write_register](modbus_write_register.md)
+- [modbus_write_registers](modbus_write_registers.md)

--- a/docs/modbus_write_bit.md
+++ b/docs/modbus_write_bit.md
@@ -24,5 +24,5 @@ errno.
 
 ## See also
 
-- [modbus_read_bits](modbus_read_bits)
-- [modbus_write_bits](modbus_write_bits)
+- [modbus_read_bits](modbus_read_bits.md)
+- [modbus_write_bits](modbus_write_bits.md)

--- a/docs/modbus_write_bits.md
+++ b/docs/modbus_write_bits.md
@@ -29,5 +29,5 @@ shall return -1 and set errno.
 
 ## See also
 
-- [modbus_read_bits](modbus_read_bits)
-- [modbus_write_bit](modbus_write_bit)
+- [modbus_read_bits](modbus_read_bits.md)
+- [modbus_write_bit](modbus_write_bit.md)

--- a/docs/modbus_write_register.md
+++ b/docs/modbus_write_register.md
@@ -24,5 +24,5 @@ errno.
 
 ## See also
 
-- [modbus_read_registers](modbus_read_registers)
-- [modbus_write_registers](modbus_write_registers)
+- [modbus_read_registers](modbus_read_registers.md)
+- [modbus_write_registers](modbus_write_registers.md)

--- a/docs/modbus_write_registers.md
+++ b/docs/modbus_write_registers.md
@@ -24,5 +24,5 @@ successful. Otherwise it shall return -1 and set errno.
 
 ## See also
 
-- [modbus_write_register](modbus_write_register)
-- [modbus_read_registers](modbus_read_registers)
+- [modbus_write_register](modbus_write_register.md)
+- [modbus_read_registers](modbus_read_registers.md)


### PR DESCRIPTION
## Issue
Documentation links on pages other than index.md point to non-existent paths, returning a 404 error when trying to navigate between pages via the on-page links. The sidebar links work fine, as do links on the homepage.

## Cause
The links in the documentation markdown are written *without* file extensions, so mkdocs appends them as sub paths of the current URL, e.g. `https://libmodbus.org/reference/modbus_new_tcp/modbus_tcp_listen` (does not exist) instead of `https://libmodbus.org/reference/modbus_tcp_listen`. This doesn't cause an issue on the index page as the current URL is `https://libmodbus.org/reference`, therefore appending the sub path creates a valid link.

## Fix
Adding file extensions to the markdown links causes mkdocs to create valid links.

## Changes
- .md was added to the documentation links so mkdocs produces the correct links
- Fixed a typo for one of the links in index.md