### PR TITLE
Catch some buildsystem errors

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,9 +6,11 @@ if autoreconf --install --symlink --force; then
 	echo "------------------------------------------------------"
 	echo
 else
+	s="$?"
 	echo
 	echo "--------------------------"
 	echo "Running autoreconf failed."
 	echo "--------------------------"
 	echo
+	exit "$s"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,9 @@ esac
 AM_CONDITIONAL(OS_WIN32, test "$os_win32" = "true")
 AM_CONDITIONAL(OS_QNX, test "$os_qnx" = "true")
 
+m4_pattern_forbid([^LT_INIT])dnl
 LT_INIT([disable-static win32-dll pic-only])
+
 AC_CHECK_HEADERS([ \
     arpa/inet.h \
     byteswap.h \


### PR DESCRIPTION
This catches some errors which can happen in the build system:

  * If `autoreconf` fails for some reason (exit with code != 0), there is no good reason for the `autogen.sh` script to succeed.(exit with code 0).

  * If the system does not have libtool installed, the `LT_INIT` m4 macro is not available and therefore the `configure` script cannot be generated properly. This should result in `autoreconf` aborting with an error, and not in the `configure` script containing a line of verbatim `LT_INIT([disable-static win32-dll pic-only])`. `m4_pattern_forbid` provides just that.

JFTR, I stumbled upon this due to https://stackoverflow.com/questions/73355119/error-libtool-library-used-but-libtool-is-undefined-but-libtool-installed-on.