### PR TITLE
fix modbus quirks function definition

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1857,19 +1857,19 @@ int modbus_get_header_length(modbus_t *ctx)
     return ctx->backend->header_length;
 }
 
-int modbus_enable_quirks(modbus_t *ctx, uint32_t quirks_mask)
+int modbus_enable_quirks(modbus_t *ctx, unsigned int quirks_mask)
 {
     if (ctx == NULL) {
         errno = EINVAL;
         return -1;
     }
 
-    /* Enable quirks that have a true value at their index in the mask */
+    /* Enable quirks that have a true value at their index in the mask */
     ctx->quirks |= quirks_mask;
     return 0;
 }
 
-int modbus_disable_quirks(modbus_t *ctx, uint32_t quirks_mask)
+int modbus_disable_quirks(modbus_t *ctx, unsigned int quirks_mask)
 {
     if (ctx == NULL) {
         errno = EINVAL;


### PR DESCRIPTION
fix `modbus_enable_quirks(...)` and `modbus_disable_quirkswhich(...)` definitions to match their declaration. 
Previously they were defined with `unsigned int` but declared with `uint32_t` which fails if the types don´t match (in my case  `uint32_t` is defined as `unsigned long` instead of `unsinged int`)