### PR TITLE
Add quirks flag MODBUS_QUIRK_IGNORE_RTU_SLAVE_CHECK.

### DIFF
--- a/docs/modbus_enable_quirks.md
+++ b/docs/modbus_enable_quirks.md
@@ -22,6 +22,8 @@ offers the following flags:
 - `MODBUS_QUIRK_MAX_SLAVE` allows slave adresses between 247 and 255.
 - `MODBUS_QUIRK_REPLY_TO_BROADCAST` force a reply to a broacast request when the
   device is a slave in RTU mode (should be enabled on the slave device).
+- `MODBUS_QUIRK_IGNORE_RTU_SLAVE_CHECK` allows no filtering on the Modbus unit
+  identifier (slave) in RTU mode while checking integrity.
 
 You can combine the flags by using the bitwise OR operator.
 

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -371,7 +371,8 @@ static int _modbus_rtu_check_integrity(modbus_t *ctx, uint8_t *msg, const int ms
     }
 
     /* Filter on the Modbus unit identifier (slave) in RTU mode */
-    if (slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS) {
+    if (slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS &&
+        !(ctx->quirks & MODBUS_QUIRK_IGNORE_RTU_SLAVE_CHECK)) {
         if (ctx->debug) {
             printf("Request for slave %d ignored (not %d)\n", slave, ctx->slave);
         }

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -185,6 +185,7 @@ typedef enum {
     MODBUS_QUIRK_NONE = 0,
     MODBUS_QUIRK_MAX_SLAVE = (1 << 1),
     MODBUS_QUIRK_REPLY_TO_BROADCAST = (1 << 2),
+    MODBUS_QUIRK_IGNORE_RTU_SLAVE_CHECK = (1 << 3),
     MODBUS_QUIRK_ALL = 0xFF
 } modbus_quirks;
 


### PR DESCRIPTION
The Modbus RTU mode currently only allows a single slave, the message is ignored when not from the expected slave.

The MODBUS_QUIRK_IGNORE_RTU_SLAVE_CHECK flag allow ignore the Modbus unit identifier (slave) checking, in this way, the RTU slave device can acts as a multi-channels gateway, receive the request messages for different slave from upstream channel, then forward those to the downstream channel in transparent mode.