### PR TITLE
Fixes float encoding/decoding for both big and little endian (fixes #665).

### DIFF
--- a/src/modbus-data.c
+++ b/src/modbus-data.c
@@ -95,11 +95,10 @@ float modbus_get_float_abcd(const uint16_t *src)
     float f;
     uint8_t a, b, c, d;
 
-    // access buffer memory byte-wise ABCD
-    a = src[0] >> 8;     // high byte if first word
-    b = src[0] & 0xFF;   // low byte if first word
-    c = src[1] >> 8;     // high byte if second word
-    d = src[1] & 0xFF;   // low byte if second word
+    a = (src[0] >> 8) & 0xFF; // high byte if first word
+    b = (src[0] >> 0) & 0xFF; // low byte if first word
+    c = (src[1] >> 8) & 0xFF; // high byte if second word
+    d = (src[1] >> 0) & 0xFF; // low byte if second word
 
     // assemble in memory location of float
     // from right to left: get address of float, interpret as address to uint32, dereference and write uint32
@@ -114,11 +113,10 @@ float modbus_get_float_dcba(const uint16_t *src)
     float f;
     uint8_t a, b, c, d;
 
-    // access buffer memory byte-wise DCBA
-    d = src[0] >> 8;     // high byte if first word
-    c = src[0] & 0xFF;   // low byte if first word
-    b = src[1] >> 8;     // high byte if second word
-    a = src[1] & 0xFF;   // low byte if second word
+    d = (src[0] >> 8) & 0xFF;
+    c = (src[0] >> 0) & 0xFF;
+    b = (src[1] >> 8) & 0xFF;
+    a = (src[1] >> 0) & 0xFF;
 
     // assemble in memory location of float
     // from right to left: get address of float, interpret as address to uint32, dereference and write uint32
@@ -133,11 +131,10 @@ float modbus_get_float_badc(const uint16_t *src)
     float f;
     uint8_t a, b, c, d;
 
-    // access buffer memory byte-wise BADC
-    b = src[0] >> 8;     // high byte if first word
-    a = src[0] & 0xFF;   // low byte if first word
-    d = src[1] >> 8;     // high byte if second word
-    c = src[1] & 0xFF;   // low byte if second word
+    b = (src[0] >> 8) & 0xFF;
+    a = (src[0] >> 0) & 0xFF;
+    d = (src[1] >> 8) & 0xFF;
+    c = (src[1] >> 0) & 0xFF;
 
     // assemble in memory location of float
     // from right to left: get address of float, interpret as address to uint32, dereference and write uint32
@@ -152,11 +149,10 @@ float modbus_get_float_cdab(const uint16_t *src)
     float f;
     uint8_t a, b, c, d;
 
-    // access buffer memory byte-wise CDAB
-    c = src[0] >> 8;     // high byte if first word
-    d = src[0] & 0xFF;   // low byte if first word
-    a = src[1] >> 8;     // high byte if second word
-    b = src[1] & 0xFF;   // low byte if second word
+    c = (src[0] >> 8) & 0xFF;
+    d = (src[0] >> 0) & 0xFF;
+    a = (src[1] >> 8) & 0xFF;
+    b = (src[1] >> 0) & 0xFF;
 
     // assemble in memory location of float
     // from right to left: get address of float, interpret as address to uint32, dereference and write uint32

--- a/src/modbus-data.c
+++ b/src/modbus-data.c
@@ -164,7 +164,7 @@ float modbus_get_float_cdab(const uint16_t *src)
 /* DEPRECATED - Get a float from 4 bytes in sort of Modbus format */
 float modbus_get_float(const uint16_t *src)
 {
-    return modbus_get_float_dcba(src);
+    return modbus_get_float_cdab(src);
 }
 
 /* Set a float to 4 bytes for Modbus w/o any conversion (ABCD) */
@@ -230,5 +230,5 @@ void modbus_set_float_cdab(float f, uint16_t *dest)
 /* DEPRECATED - Set a float to 4 bytes in a sort of Modbus format! */
 void modbus_set_float(float f, uint16_t *dest)
 {
-    return modbus_set_float_dcba(f, dest);
+    return modbus_set_float_cdab(f, dest);
 }


### PR DESCRIPTION
Fixes float encoding/decoding for both big and little endian (fixes #665).
Also removes useless memcpy calls and no longer used swap32 and swap16 macros.

This pullrequest modifies a single file. As explained in issue #665, the byte positions in target modbus buffer must be explicitely set according to the modbus protocol specs.

Both for encoding/decoding a cross-platform way working for both big and little endian systems is the use of 32-bit integers. That means, we interpret the memory of the 32-bit float as 32-bit integer, then extract the byte via shift operations. Hereby, the compiler takes care of the big/little endian memory layout of our float/integer. 

The new code is way faster than the previous, as the memcpy operations are no longer needed. The type casts may look ugly at first glance, but really describe what we want to achive:

```
float f;
float * f_ptr = &f;  // pointer to float
uint32_t * i_ptr = (uint32_*)f_ptr; // interpret as pointer to uint32
uint32_t i = *i_ptr; // get the integer value at this memory location
```

putting this all together:

```
*(uint32_t*)(&f) = integer number
```
