### PR TITLE
use poll() instead of select() when possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,7 @@ AC_CHECK_HEADERS([ \
     netdb.h \
     netinet/in.h \
     netinet/tcp.h \
+    poll.h \
     sys/ioctl.h \
     sys/params.h \
     sys/socket.h \
@@ -104,7 +105,7 @@ AC_CHECK_DECLS([__CYGWIN__])
 AC_SEARCH_LIBS(accept, network socket)
 
 # Checks for library functions.
-AC_CHECK_FUNCS([accept4 getaddrinfo gettimeofday inet_pton inet_ntop select socket strerror strlcpy])
+AC_CHECK_FUNCS([accept4 getaddrinfo gettimeofday inet_pton inet_ntop poll select socket strerror strlcpy])
 
 # Required for MinGW with GCC v4.8.1 on Win7
 AC_DEFINE(WINVER, 0x0501, _)

--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -89,7 +89,7 @@ typedef struct _modbus_backend {
     unsigned int (*is_connected)(modbus_t *ctx);
     void (*close)(modbus_t *ctx);
     int (*flush)(modbus_t *ctx);
-    int (*select)(modbus_t *ctx, fd_set *rset, struct timeval *tv, int msg_length);
+    int (*select)(modbus_t *ctx, struct timeval *tv, int msg_length);
     void (*free)(modbus_t *ctx);
 } modbus_backend_t;
 

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -1154,7 +1154,7 @@ _modbus_rtu_select(modbus_t *ctx, struct timeval *tv, int length_to_read)
     fds.fd = ctx->s;
     fds.events = POLLIN;
     fds.revents = 0;
-    while ((s_rc = poll(&fds, 1, tv->tv_sec * 1000 + tv->tv_usec / 1000)) == -1) {
+    while ((s_rc = poll(&fds, 1, (tv != NULL) ? tv->tv_sec * 1000 + tv->tv_usec / 1000 : -1)) == -1) {
         if (errno == EINTR) {
             if (ctx->debug) {
                 fprintf(stderr, "A non blocked signal was caught\n");

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -297,7 +297,7 @@ static int _connect(int sockfd,
         fds.fd = sockfd;
         fds.events = POLLOUT;
         fds.revents = 0;
-        rc = poll(&fds, 1, ro_tv->tv_sec * 1000 + ro_tv->tv_usec / 1000);
+        rc = poll(&fds, 1, (ro_tv != NULL) ? ro_tv->tv_sec * 1000 + ro_tv->tv_usec / 1000 : -1);
 #else
         fd_set wset;
         struct timeval tv = *ro_tv;
@@ -786,7 +786,7 @@ _modbus_tcp_select(modbus_t *ctx, struct timeval *tv, int length_to_read)
     fds.fd = ctx->s;
     fds.events = POLLIN;
     fds.revents = 0;
-    while ((s_rc = poll(&fds, 1, tv->tv_sec * 1000 + tv->tv_usec / 1000)) == -1) {
+    while ((s_rc = poll(&fds, 1, (tv != NULL) ? tv->tv_sec * 1000 + tv->tv_usec / 1000 : -1)) == -1) {
         if (errno == EINTR) {
             if (ctx->debug) {
                 fprintf(stderr, "A non blocked signal was caught\n");

--- a/src/modbus.c
+++ b/src/modbus.c
@@ -350,7 +350,6 @@ compute_data_length_after_meta(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
 int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
 {
     int rc;
-    fd_set rset;
     struct timeval tv;
     struct timeval *p_tv;
     unsigned int length_to_read;
@@ -374,10 +373,6 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
         }
         return -1;
     }
-
-    /* Add a file descriptor to the set */
-    FD_ZERO(&rset);
-    FD_SET(ctx->s, &rset);
 
     /* We need to analyse the message step by step.  At the first step, we want
      * to reach the function code because all packets contain this
@@ -405,7 +400,7 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
     }
 
     while (length_to_read != 0) {
-        rc = ctx->backend->select(ctx, &rset, p_tv, length_to_read);
+        rc = ctx->backend->select(ctx, p_tv, length_to_read);
         if (rc == -1) {
             _error_print(ctx, "select");
             if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) {


### PR DESCRIPTION
Currently libmodbus uses select() on Linux. If socket handle is greater than FD_SETSIZE select call causes application crash due to buffer overflow. Proposed pull request uses poll() instead of select() when available as well as fails attempts to call select on sockets >= FD_SETSIZE with EBADF.
Situation with socket handle being greater that FD_SETSIZE is not uncommon for applications that keeps hundreds of connections.
