### PR TITLE
Small compatibility improvements for esp32 embedded platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,7 @@ AC_CHECK_DECLS([__CYGWIN__])
 AC_SEARCH_LIBS(accept, network socket)
 
 # Checks for library functions.
-AC_CHECK_FUNCS([accept4 getaddrinfo gettimeofday inet_pton inet_ntop select socket strerror strlcpy])
+AC_CHECK_FUNCS([accept4 gai_strerror getaddrinfo gettimeofday inet_pton inet_ntop select socket strerror strlcpy])
 
 # Required for MinGW with GCC v4.8.1 on Win7
 AC_DEFINE(WINVER, 0x0501, _)

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,7 @@ AC_CHECK_HEADERS([ \
     linux/serial.h \
     netdb.h \
     netinet/in.h \
+    netinet/ip.h \
     netinet/tcp.h \
     sys/ioctl.h \
     sys/params.h \

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -403,7 +403,11 @@ static int _modbus_tcp_pi_connect(modbus_t *ctx)
     rc = getaddrinfo(ctx_tcp_pi->node, ctx_tcp_pi->service, &ai_hints, &ai_list);
     if (rc != 0) {
         if (ctx->debug) {
+#ifdef HAVE_GAI_STRERROR
             fprintf(stderr, "Error returned by getaddrinfo: %s\n", gai_strerror(rc));
+#else
+            fprintf(stderr, "Error returned by getaddrinfo: %d\n", rc);
+#endif
         }
         freeaddrinfo(ai_list);
         errno = ECONNREFUSED;
@@ -629,7 +633,11 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
     rc = getaddrinfo(node, service, &ai_hints, &ai_list);
     if (rc != 0) {
         if (ctx->debug) {
+#ifdef HAVE_GAI_STRERROR
             fprintf(stderr, "Error returned by getaddrinfo: %s\n", gai_strerror(rc));
+#else
+            fprintf(stderr, "Error returned by getaddrinfo: %d\n", rc);
+#endif
         }
         freeaddrinfo(ai_list);
         errno = ECONNREFUSED;

--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -41,7 +41,9 @@
 #endif
 
 # include <netinet/in.h>
+#ifdef HAVE_NETINET_IP_H
 # include <netinet/ip.h>
+#endif
 # include <netinet/tcp.h>
 # include <arpa/inet.h>
 # include <netdb.h>


### PR DESCRIPTION
This PR adds a few small compatibility improvements for embedded platforms, specifically for the esp32 family using ESP-IDF, which are based on lwip. With these small modifications and by providing an external `nanosleep` (no need to pollute libmodbus as one can provide it externally in the project) then the library can be used in TCP mode in ESP-IDF.

The changes are not enough for using it with serial ports, I may send another PR for that (it will be a little more complicated as there we need to change the init part using the UART library for that system). 

Would you be interested to have that in case in the codebase? (of course with a separate `#define` to replace the `modbus_rtu_connect` when one chooses that specific platform, a bit like you already have WIN32/Posix differentiation)