### PR TITLE
modbus-rtu: don't use O_EXCL when opening the device

### DIFF
--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -639,7 +639,7 @@ static int _modbus_rtu_connect(modbus_t *ctx)
 
        Timeouts are ignored in canonical input mode or when the
        NONBLOCK option is set on the file via open or fcntl */
-    flags = O_RDWR | O_NOCTTY | O_NONBLOCK | O_EXCL;
+    flags = O_RDWR | O_NOCTTY | O_NONBLOCK;
 #ifdef O_CLOEXEC
     flags |= O_CLOEXEC;
 #endif


### PR DESCRIPTION
Quote from 'man 2 open':
-snip-
...
In general, the behavior of O_EXCL is undefined if it is used without O_CREAT. ...
-snap-

Since we don't create the device file here - we just want to open (hopefully) existing ones - let's simply drop this flag to be on the safe side.