### PR TITLE
HAVE_NETINET_IN_H as guard around header

### DIFF
--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -40,8 +40,12 @@
 # include <netinet/in_systm.h>
 #endif
 
-# include <netinet/in.h>
-# include <netinet/ip.h>
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif /* HAVE_NETINET_IN_H */
+#ifdef HAVE_NETINET_IP_H
+#include <netinet/ip.h>
+#endif /* HAVE_NETINET_IP_H */
 # include <netinet/tcp.h>
 # include <arpa/inet.h>
 # include <netdb.h>

--- a/tests/bandwidth-server-many-up.c
+++ b/tests/bandwidth-server-many-up.c
@@ -17,7 +17,9 @@
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>
+#ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#endif /* HAVE_NETINET_IN_H */
 #include <sys/select.h>
 #include <sys/socket.h>
 #endif


### PR DESCRIPTION
Hi, 

it does not make sense to have this in a config.h, and then still include it when HAVE_NETINET_IN_H is 0. 

This fix solves this. 

