### PR TITLE
New API functions to access constructed response frame #786

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -784,11 +784,31 @@ int modbus_reply(modbus_t *ctx,
                  int req_length,
                  modbus_mapping_t *mb_mapping)
 {
+    uint8_t rsp[MAX_MESSAGE_LENGTH];
+    int rsp_length;
+
+    rsp_length = modbus_reply_construct(ctx, req, req_length, mb_mapping, rsp);
+    if (rsp_length > 0) {
+        return send_msg(ctx, rsp, rsp_length);
+    }
+    return rsp_length;
+}
+
+/* Analyses the request and constructs a response.
+
+   If an error occurs, this function constructs the response
+   accordingly.
+*/
+int modbus_reply_construct(modbus_t *ctx,
+                           const uint8_t *req,
+                           int req_length,
+                           modbus_mapping_t *mb_mapping,
+                           uint8_t *rsp)
+{
     unsigned int offset;
     int slave;
     int function;
     uint16_t address;
-    uint8_t rsp[MAX_MESSAGE_LENGTH];
     int rsp_length = 0;
     sft_t sft;
 
@@ -1189,7 +1209,15 @@ int modbus_reply(modbus_t *ctx,
         !(ctx->quirks & MODBUS_QUIRK_REPLY_TO_BROADCAST)) {
         return 0;
     }
-    return send_msg(ctx, rsp, rsp_length);
+    return rsp_length;
+}
+
+int modbus_reply_send(modbus_t *ctx, uint8_t *rsp, int rsp_length)
+{
+    if (rsp_length > 0) {
+        return send_msg(ctx, rsp, rsp_length);
+    }
+    return rsp_length;
 }
 
 int modbus_reply_exception(modbus_t *ctx, const uint8_t *req, unsigned int exception_code)

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -275,6 +275,10 @@ MODBUS_API int modbus_reply(modbus_t *ctx,
                             int req_length,
                             modbus_mapping_t *mb_mapping);
 MODBUS_API int
+modbus_reply_construct(modbus_t *ctx, const uint8_t *req,
+                       int req_length, modbus_mapping_t *mb_mapping, uint8_t *rsp);
+MODBUS_API int modbus_reply_send(modbus_t *ctx, uint8_t *rsp, int rsp_length);
+MODBUS_API int
 modbus_reply_exception(modbus_t *ctx, const uint8_t *req, unsigned int exception_code);
 MODBUS_API int modbus_enable_quirks(modbus_t *ctx, unsigned int quirks_mask);
 MODBUS_API int modbus_disable_quirks(modbus_t *ctx, unsigned int quirks_mask);


### PR DESCRIPTION
It is crucial to have access to the modbus frames in order to diagnose communication problems. The incoming frame is already available via API but the response frame sent by the modbus server is not.
By adding two extra API functions, we provide access to the response frame without affecting compatibility with previous implementations.
