### PR TITLE
WIN32 compatibility for setsockopt() in modbus-tcp.c

### DIFF
--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -236,7 +236,11 @@ static int _modbus_tcp_set_ipv4_options(int s)
     /* Set the TCP no delay flag */
     /* SOL_TCP = IPPROTO_TCP */
     option = 1;
-    rc = setsockopt(s, IPPROTO_TCP, TCP_NODELAY, &option, sizeof(int));
+#ifdef _WIN32
+    rc = setsockopt(s, IPPROTO_TCP, TCP_NODELAY, (const char *)&option, sizeof(int));
+#else
+    rc = setsockopt(s, IPPROTO_TCP, TCP_NODELAY, (const void *)&option, sizeof(int));
+#endif
     if (rc == -1) {
         return -1;
     }
@@ -264,7 +268,11 @@ static int _modbus_tcp_set_ipv4_options(int s)
      **/
     /* Set the IP low delay option */
     option = IPTOS_LOWDELAY;
-    rc = setsockopt(s, IPPROTO_IP, IP_TOS, &option, sizeof(int));
+#ifdef _WIN32
+    rc = setsockopt(s, IPPROTO_IP, IP_TOS, (const char *)&option, sizeof(int));
+#else
+    rc = setsockopt(s, IPPROTO_IP, IP_TOS, (const void *)&option, sizeof(int));
+#endif
     if (rc == -1) {
         return -1;
     }
@@ -563,7 +571,11 @@ int modbus_tcp_listen(modbus_t *ctx, int nb_connection)
     }
 
     enable = 1;
-    if (setsockopt(new_s, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) == -1) {
+#ifdef _WIN32
+    if (setsockopt(new_s, SOL_SOCKET, SO_REUSEADDR, (const char *)&enable, sizeof(enable)) == -1) {
+#else
+    if (setsockopt(new_s, SOL_SOCKET, SO_REUSEADDR, (const void *)&enable, sizeof(enable)) == -1) {
+#endif
         close(new_s);
         return -1;
     }
@@ -680,7 +692,11 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
             continue;
         } else {
             int enable = 1;
-            rc = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+#ifdef _WIN32
+            rc = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (const char *)&enable, sizeof(enable));
+#else
+            rc = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (const void *)&enable, sizeof(enable));
+#endif
             if (rc != 0) {
                 close(s);
                 if (ctx->debug) {


### PR DESCRIPTION
UNIX systems [<sys/socket.h>](https://www.ibm.com/docs/en/zos/3.1.0?topic=functions-setsockopt-set-options-associated-socket) require const void *, while Windows [<winsock2.h>](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-setsockopt) const char *. Previous version without type casting did not build on Windows, resulting in:

>   CC       modbus-tcp.lo
modbus-tcp.c: In function '_modbus_tcp_set_ipv4_options':
modbus-tcp.c:239:50: error: passing argument 4 of 'setsockopt' from incompatible pointer type [-Wincompatible-pointer-types]
  239 |     rc = setsockopt(s, IPPROTO_TCP, TCP_NODELAY, &option, sizeof(int));
      |                                                  ^~~~~~~
      |                                                  |
      |                                                  int *
In file included from modbus-tcp.c:31:
C:/msys64/mingw64/include/winsock2.h:1035:88: note: expected 'const char *' but argument is of type 'int *'
 1035 |   WINSOCK_API_LINKAGE int WSAAPI setsockopt(SOCKET s,int level,int optname,const char *optval,int optlen);
      |                                                                            ~~~~~~~~~~~~^~~~~~
modbus-tcp.c: In function 'modbus_tcp_listen':
modbus-tcp.c:566:53: error: passing argument 4 of 'setsockopt' from incompatible pointer type [-Wincompatible-pointer-types]
  566 |     if (setsockopt(new_s, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) == -1) {
      |                                                     ^~~~~~~
      |                                                     |
      |                                                     int *
C:/msys64/mingw64/include/winsock2.h:1035:88: note: expected 'const char *' but argument is of type 'int *'
 1035 |   WINSOCK_API_LINKAGE int WSAAPI setsockopt(SOCKET s,int level,int optname,const char *optval,int optlen);
      |                                                                            ~~~~~~~~~~~~^~~~~~
modbus-tcp.c: In function 'modbus_tcp_pi_listen':
modbus-tcp.c:683:58: error: passing argument 4 of 'setsockopt' from incompatible pointer type [-Wincompatible-pointer-types]
  683 |             rc = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
      |                                                          ^~~~~~~
      |                                                          |
      |                                                          int *
C:/msys64/mingw64/include/winsock2.h:1035:88: note: expected 'const char *' but argument is of type 'int *'
 1035 |   WINSOCK_API_LINKAGE int WSAAPI setsockopt(SOCKET s,int level,int optname,const char *optval,int optlen);
      |                                                                            ~~~~~~~~~~~~^~~~~~
make[2]: *** [Makefile:486: modbus-tcp.lo] Error 1
make[1]: *** [Makefile:505: all-recursive] Error 1
make: *** [Makefile:391: all] Error 2

#721 