### PR TITLE
Adds API to suppress echo

### DIFF
--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -72,6 +72,9 @@ typedef struct _modbus_rtu {
 #endif
     /* To handle many slaves on the same link */
     int confirmation_to_ignore;
+    /* software-side local echo suppression of sent bytes since hardware
+     * does not support it or is configured to not do it */
+    bool is_echo_suppressing;
 } modbus_rtu_t;
 
 #endif /* MODBUS_RTU_PRIVATE_H */

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -7,6 +7,7 @@
 #ifndef MODBUS_RTU_H
 #define MODBUS_RTU_H
 
+#include <stdbool.h>
 #include "modbus.h"
 
 MODBUS_BEGIN_DECLS
@@ -39,5 +40,8 @@ MODBUS_API int modbus_rtu_set_rts_delay(modbus_t *ctx, int us);
 MODBUS_API int modbus_rtu_get_rts_delay(modbus_t *ctx);
 
 MODBUS_END_DECLS
+
+int modbus_rtu_set_suppress_echo(modbus_t *ctx, bool on);
+int modbus_rtu_get_suppress_echo(modbus_t *ctx);
 
 #endif /* MODBUS_RTU_H */


### PR DESCRIPTION
Several people (including myself) have come across an issue for half-duplex rs485 networks where on some hardware, the data that is transmitted is also received as the response. This of course causes issues with being able to send/receive modbus messages.

This PR adds an API call to set a flag that when enabled, will read and ignore the number of bytes written to the socket during send requests. This has been reworked/refactored from several existing PRs (one from 2011 and one from 2018).

I tested this locally against my own hardware that has this echo issue, and this PR fixes the issue I've been seeing.