### PR TITLE
Adds API to suppress echo

### DIFF
--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -72,6 +72,9 @@ typedef struct _modbus_rtu {
 #endif
     /* To handle many slaves on the same link */
     int confirmation_to_ignore;
+    /* software-side local echo suppression of sent bytes since hardware
+     * does not support it or is configured to not do it */
+    bool is_echo_suppressing;
 } modbus_rtu_t;
 
 #endif /* MODBUS_RTU_PRIVATE_H */

--- a/src/modbus-rtu-private.h
+++ b/src/modbus-rtu-private.h
@@ -74,7 +74,7 @@ typedef struct _modbus_rtu {
     int confirmation_to_ignore;
     /* software-side local echo suppression of sent bytes since hardware
      * does not support it or is configured to not do it */
-    bool is_echo_suppressing;
+    int is_echo_suppressing;
 } modbus_rtu_t;
 
 #endif /* MODBUS_RTU_PRIVATE_H */

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -269,6 +269,7 @@ static ssize_t _modbus_rtu_suppress_echo_write(int fd, int debug, const uint8_t 
 
     // return immediately on error
     if (count < 0) {
+      errno = EMBBADECHO;
       return -1;
     }
 
@@ -291,6 +292,7 @@ static ssize_t _modbus_rtu_suppress_echo_write(int fd, int debug, const uint8_t 
             "ERROR: during echo suppression, sent %d bytes, read back %d bytes\n",
             write_size,
             read_size);
+    errno = EMBBADECHO;
     return -1;
   }
 
@@ -304,6 +306,7 @@ static ssize_t _modbus_rtu_suppress_echo_write(int fd, int debug, const uint8_t 
               i,
               req_echo[i],
               i);
+      errno = EMBBADECHO;
       return -1;
     }
   }

--- a/src/modbus-rtu.c
+++ b/src/modbus-rtu.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif
@@ -251,6 +252,56 @@ static void _modbus_rtu_ioctl_rts(modbus_t *ctx, int on)
 }
 #endif
 
+static ssize_t _modbus_rtu_suppress_echo_write(modbus_t *ctx, const uint8_t *req, int req_length) {
+  ssize_t write_size, read_size, count;
+  uint8_t req_echo[MODBUS_RTU_MAX_ADU_LENGTH];
+  time_t start_time;
+
+  write_size = write(ctx->s, req, req_length);
+
+  read_size = 0;
+  count = 0;
+  start_time = time(NULL);
+  // Time limit the loop to 3 seconds in case the read continuously returns 0 bytes read
+  while (read_size < write_size && difftime(time(NULL), start_time) < 3)
+  {
+    count += read(ctx->s, &req_echo[read_size], write_size - read_size);
+
+    // return immediately on error
+    if (count < 0) {
+      return -1;
+    }
+
+    read_size += count;
+  }
+
+  if (ctx->debug)
+  {
+    printf("Read back %d bytes echoed from the socket\n", read_size);
+    for (int i = 0; i < read_size; i++)
+    {
+      fprintf(stderr, "|%02X|", req_echo[i]);
+    }
+    fprintf(stderr, "\n");
+  }
+
+  for (int i = 0; i < read_size; i++)
+  {
+    if (req[i] != req_echo[i])
+    {
+      fprintf(stderr,
+              "ERROR: during echo suppression, sent 0x%02X for byte req[%d] of the request, read back 0x%02X for byte echo[%d] of the echo\n",
+              req[i],
+              i,
+              req_echo[i],
+              i);
+      return -1;
+    }
+  }
+
+  return write_size;
+}
+
 static ssize_t _modbus_rtu_send(modbus_t *ctx, const uint8_t *req, int req_length)
 {
 #if defined(_WIN32)
@@ -272,7 +323,11 @@ static ssize_t _modbus_rtu_send(modbus_t *ctx, const uint8_t *req, int req_lengt
         ctx_rtu->set_rts(ctx, ctx_rtu->rts == MODBUS_RTU_RTS_UP);
         usleep(ctx_rtu->rts_delay);
 
-        size = write(ctx->s, req, req_length);
+        if (!ctx_rtu->is_echo_suppressing) {
+            size = write(ctx->s, req, req_length);
+        } else {
+            size = _modbus_rtu_suppress_echo_write(ctx, req, req_length);
+        }
 
         usleep(ctx_rtu->onebyte_time * req_length + ctx_rtu->rts_delay);
         ctx_rtu->set_rts(ctx, ctx_rtu->rts != MODBUS_RTU_RTS_UP);
@@ -280,7 +335,11 @@ static ssize_t _modbus_rtu_send(modbus_t *ctx, const uint8_t *req, int req_lengt
         return size;
     } else {
 #endif
-        return write(ctx->s, req, req_length);
+        if (!ctx_rtu->is_echo_suppressing) {
+            return write(ctx->s, req, req_length);
+        } else {
+            return _modbus_rtu_suppress_echo_write(ctx, req, req_length);
+        }
 #if HAVE_DECL_TIOCM_RTS
     }
 #endif
@@ -1089,6 +1148,37 @@ int modbus_rtu_set_rts_delay(modbus_t *ctx, int us)
     }
 }
 
+int modbus_rtu_set_suppress_echo(modbus_t* ctx, bool on) {
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU) {
+        modbus_rtu_t* rtu = (modbus_rtu_t*) ctx->backend_data;
+        rtu->is_echo_suppressing = on;
+        return 0;
+    }
+
+    errno = EINVAL;
+    return -1;
+}
+
+int modbus_rtu_get_suppress_echo(modbus_t* ctx) {
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_RTU) {
+        modbus_rtu_t* rtu = (modbus_rtu_t*) ctx->backend_data;
+        return rtu->is_echo_suppressing;
+    }
+
+    errno = EINVAL;
+    return -1;
+}
+
 static void _modbus_rtu_close(modbus_t *ctx)
 {
     /* Restore line settings and close file descriptor in RTU mode */
@@ -1283,6 +1373,7 @@ modbus_new_rtu(const char *device, int baud, char parity, int data_bit, int stop
 #endif
 
     ctx_rtu->confirmation_to_ignore = FALSE;
+    ctx_rtu->is_echo_suppressing = FALSE;
 
     return ctx;
 }

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -7,7 +7,6 @@
 #ifndef MODBUS_RTU_H
 #define MODBUS_RTU_H
 
-#include <stdbool.h>
 #include "modbus.h"
 
 MODBUS_BEGIN_DECLS
@@ -41,7 +40,7 @@ MODBUS_API int modbus_rtu_get_rts_delay(modbus_t *ctx);
 
 MODBUS_END_DECLS
 
-int modbus_rtu_set_suppress_echo(modbus_t *ctx, bool on);
+int modbus_rtu_set_suppress_echo(modbus_t *ctx, int on);
 int modbus_rtu_get_suppress_echo(modbus_t *ctx);
 
 #endif /* MODBUS_RTU_H */

--- a/src/modbus-rtu.h
+++ b/src/modbus-rtu.h
@@ -7,6 +7,7 @@
 #ifndef MODBUS_RTU_H
 #define MODBUS_RTU_H
 
+#include <stdbool.h>
 #include "modbus.h"
 
 MODBUS_BEGIN_DECLS
@@ -39,5 +40,8 @@ MODBUS_API int modbus_rtu_set_rts_delay(modbus_t *ctx, int us);
 MODBUS_API int modbus_rtu_get_rts_delay(modbus_t *ctx);
 
 MODBUS_END_DECLS
+
+int modbus_rtu_set_suppress_echo(modbus_t *ctx, bool on);
+int modbus_rtu_get_suppress_echo(modbus_t *ctx);
 
 #endif /* MODBUS_RTU_H */

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -149,6 +149,7 @@ enum {
 #define EMBUNKEXC   (EMBXGTAR + 4)
 #define EMBMDATA    (EMBXGTAR + 5)
 #define EMBBADSLAVE (EMBXGTAR + 6)
+#define EMBBADECHO  (EMBXGTAR + 7)
 
 extern const unsigned int libmodbus_version_major;
 extern const unsigned int libmodbus_version_minor;


### PR DESCRIPTION
Several people (including myself) have come across an issue for half-duplex rs485 networks where on some hardware, the data that is transmitted is also received as the response. This of course causes issues with being able to send/receive modbus messages.

This PR adds an API call to set a flag that when enabled, will read and ignore the number of bytes written to the socket during send requests. This has been reworked/refactored from several existing PRs (one from 2011 and one from 2018).

I tested this locally against my own hardware that has this echo issue, and this PR fixes the issue I've been seeing.