### PR TITLE
Add modbus_get_errno function for DLL

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1915,6 +1915,11 @@ int modbus_get_header_length(modbus_t *ctx)
     return ctx->backend->header_length;
 }
 
+int modbus_get_errno()
+{
+    return errno;
+}
+
 int modbus_enable_quirks(modbus_t *ctx, unsigned int quirks_mask)
 {
     if (ctx == NULL) {

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -211,6 +211,8 @@ modbus_set_indication_timeout(modbus_t *ctx, uint32_t to_sec, uint32_t to_usec);
 
 MODBUS_API int modbus_get_header_length(modbus_t *ctx);
 
+MODBUS_API int modbus_get_errno();
+
 MODBUS_API int modbus_connect(modbus_t *ctx);
 MODBUS_API void modbus_close(modbus_t *ctx);
 


### PR DESCRIPTION
related issue #579 
I add modbus_get_errno function to handling error on DLL.
I think this is helpful for DLL users to handling the errors.