### PR TITLE
Prevent segfault in TCP connect when using MUSL 

### DIFF
--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -658,7 +658,9 @@ int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection)
             fprintf(stderr, "Error returned by getaddrinfo: %d\n", rc);
 #endif
         }
-        freeaddrinfo(ai_list);
+        if (ai_list != NULL) {
+            freeaddrinfo(ai_list);
+        }
         errno = ECONNREFUSED;
         return -1;
     }


### PR DESCRIPTION
Passing null to `freeaddrinfo` is undefined behaviour. While glibc and uClibc both handle it safely, [musl does not](https://git.musl-libc.org/cgit/musl/tree/src/network/freeaddrinfo.c), so a bad nodename or servname causes a segfault.

This change ensures that the ai_list is non-null before trying to free it in the `connect` function. [The check already exists for `listen`](https://github.com/stephane/libmodbus/blob/abcb12c998cb2c93d2bbfed39405e228c34449fe/src/modbus-tcp.c#L661)

In musl and glibc this condition will never be met, meaning `freeaddrinfo` will never actually be ran. There's no possibility for errors to be returned after memory allocation occurs in those implementations either, so there's no remaining risk of memory leaks.

In uClibc, there are some code paths where errors occur after memory is allocated, and this still guarantees it will get freed.