### PR TITLE
(RFC-compliance: Issue813) A violation regarding the specifications for the Read Exception Status.

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -1070,11 +1070,12 @@ int modbus_reply(modbus_t *ctx,
         rsp[byte_count_pos] = rsp_length - byte_count_pos - 1;
     } break;
     case MODBUS_FC_READ_EXCEPTION_STATUS:
-        if (ctx->debug) {
-            fprintf(stderr, "FIXME Not implemented\n");
-        }
-        errno = ENOPROTOOPT;
-        return -1;
+        rsp_length = response_exception(ctx,
+                                        &sft,
+                                        MODBUS_EXCEPTION_ILLEGAL_FUNCTION,
+                                        rsp,
+                                        TRUE,
+                                        "FIXME Not implemented: READ EXCEPTION STATUS (0x07)\n");
         break;
     case MODBUS_FC_MASK_WRITE_REGISTER: {
         int mapping_address = address - mb_mapping->start_registers;


### PR DESCRIPTION
We respectfully submit this pull request in order to improve the consistency between libmodbus and its specification.

- Fix: #813 
- To address this issue, we added expected warning logic for the unimplemented command (READ EXCEPTION STATUS).

## Why is this PR needed?
In the previous implementation of libmodbus, when modbus clients send the valid but unimplemented command READ EXCEPTION STATUS,  there is no response from the server. Therefore, clients will be confused. They are unable to distinguish between an unimplemented condition and a syntax error.  

## Why can this PR be safely merged?
We have only added the expected handling for unimplemented command types, without modifying any existing functionality. Therefore, our PR can be safely merged without affecting compatibility with actual clients.

**We totally respect the priority: Real-world client compatibility > Theoretical RFC compliance, and are more than happy to assist in improving RFC compliance based on this foundation.**

Thank you for your attention, and we look forward to your response : )