### PR TITLE
(RFC-compliance: Issue834) Fix the Violation of the requirement of Unit Identifier.

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -806,6 +806,12 @@ int modbus_reply(modbus_t *ctx,
     sft.function = function;
     sft.t_id = ctx->backend->get_response_tid(req);
 
+    if (slave != 0 && slave != 255) {
+        errno = EINVAL;
+        printf("The Unit Identifier must be 0x00 or 0xFF\n");
+        return -1;
+    }
+
     /* Data are flushed on illegal number of values errors. */
     switch (function) {
     case MODBUS_FC_READ_COILS:


### PR DESCRIPTION
We respectfully submit this pull request in order to improve the consistency between libmodbus and its specification.

- Fix: #834  
- To address this issue, we implemented a validation check and warning mechanism for invalid unit identifier values.

We totally respect the priority: Real-world client compatibility > Theoretical RFC compliance, and are more than happy to assist in improving RFC compliance based on this foundation.

Thank you for your attention, and we look forward to your response : )