### PR TITLE
Respect user-provided CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,10 @@ AC_INIT([libmodbus],
 AC_CONFIG_SRCDIR([src/modbus.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([check-news foreign 1.11 silent-rules tar-pax subdir-objects])
+
+# Check if user provided CFLAGS before AC_PROG_CC sets defaults
+user_set_cflags="${CFLAGS+set}"
+
 AC_PROG_CC
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
@@ -178,13 +182,18 @@ AC_ARG_ENABLE([debug],
   [enable_debug=$enableval],
   [enable_debug=no])
 
+# Set project-specific optimization flags based on debug mode.
+# These are added via AM_CFLAGS in Makefile.am, preserving user's CFLAGS.
 AS_IF([test "x$enable_debug" = "xyes"], [
-  CFLAGS="-g -O0"
-  CXXFLAGS="-g -O0"
+  LIBMODBUSCFLAGS="-g -O0"
+  # Clear AC_PROG_CC's default -O2 so debug mode works, unless user set CFLAGS
+  AS_IF([test "x$user_set_cflags" != "xset"], [
+    CFLAGS="-g"
+  ])
 ], [
-  CFLAGS="-O2"
-  CXXFLAGS="-O2"
+  LIBMODBUSCFLAGS="-O2"
 ])
+AC_SUBST([LIBMODBUSCFLAGS])
 
 AC_OUTPUT
 AC_MSG_RESULT([
@@ -197,7 +206,7 @@ AC_MSG_RESULT([
         includedir:             ${includedir}
 
         compiler:               ${CC}
-        cflags:                 ${CFLAGS} ${WARNING_CFLAGS}
+        cflags:                 ${LIBMODBUSCFLAGS} ${WARNING_CFLAGS} ${CFLAGS}
         ldflags:                ${LDFLAGS}
 
         tests:                  ${enable_tests}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ AM_CPPFLAGS = \
     -DLIBEXECDIR=\""$(libexecdir)"\" \
     -I${top_srcdir}/src
 
-AM_CFLAGS = ${WARNING_CFLAGS}
+AM_CFLAGS = $(LIBMODBUSCFLAGS) $(WARNING_CFLAGS)
 
 libmodbus_la_SOURCES = \
         modbus.c \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -44,7 +44,7 @@ AM_CPPFLAGS = \
     -I${top_srcdir}/src \
     -I${top_builddir}/src
 
-AM_CFLAGS = ${WARNING_CFLAGS}
+AM_CFLAGS = $(LIBMODBUSCFLAGS) $(WARNING_CFLAGS)
 
 CLEANFILES = *~ *.log
 


### PR DESCRIPTION
configure.ac unconditionally overwrote CFLAGS, ignoring user-provided flags. Running `CFLAGS="-O3 -march=native" ./configure` had no effect.

Fix by using LIBMODBUS_CFLAGS via AM_CFLAGS in Makefile.am, following standard autoconf/automake conventions. User CFLAGS are now appended last and can override project defaults.

Behavior:
- ./configure                             : -O2 (unchanged)
- ./configure --enable-debug              : -g -O0 (unchanged)
- CFLAGS="-O3" ./configure                : -O3 (now respected)
- CFLAGS="-O3" ./configure --enable-debug : -O3 (user priority)

Also removes unused CXXFLAGS handling (pure C library).

Closes #830.

This will also allow proper coverage tracking on oss-fuzz (https://introspector.oss-fuzz.com/project-profile?project=libmodbus). Currently, coverage is only collected for the harness code. This change should enable coverage tracking for all code.