### PR TITLE
Fix ssize_t int redefinition error on Windows

### DIFF
--- a/src/modbus-private.h
+++ b/src/modbus-private.h
@@ -14,7 +14,9 @@
 #else
 # include "stdint.h"
 # include <time.h>
+#ifndef ssize_t
 typedef int ssize_t;
+#endif
 #endif
 // clang-format on
 #include <config.h>


### PR DESCRIPTION
Greetings!

When building libmodbus 3.1.12 on Windows with MSVC, the following error is listed:

```
C:\j\30083-4\b\libmo5c5caf0ed39b5\b\src\src\modbus-private.h(17): error C2632: 'int' followed by 'int' is illegal
make[2]: *** [Makefile:489: modbus.lo] Error 1
```

The full build log can be found here: https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-30083/4/package_build_logs/build_log_libmodbus_3_1_12_b07e4eebf5b5cd0ff2c2ef1dc2a0bfbe_19e318a866610969ae17aaa36552350ac86725f0.txt

We noted that error when packaging libmodbus for Conan Center, on the PR https://github.com/conan-io/conan-center-index/pull/30083. And may be related to https://github.com/stephane/libmodbus/commit/23dd803f3f2b7be668408fa938e8d665249b4fba

As the type [ssize_t](https://manpages.debian.org/bullseye/manpages/ssize_t.3.en.html#ssize_t) is POSIX, when running `configure` on Windows, the setup can't find `ssize_t` via [AC_TYPE_SSIZE_T](https://github.com/stephane/libmodbus/blob/v3.1.12/configure.ac#L126) and writes `#define ssize_t int` into `config.h` as a result. Then, when `config.h` gets included before that `typedef`, the preprocessor expands `typedef int ssize_t` into `typedef int int`, which is invalid by the msvc compiler.

This PR adds a guard to prevent redefining `ssize_t`, so mitigating this error as on Linux and other will not have effect, but on Windows will really consume the already defined `ssize_t` from `config.h`. This idea is actually being used by the Conan recipe for libmodbus on previous version too.

I tested this patch locally, over libmodbus 3.1.12 on Windows: [libmodbus-3.1.12-windows-amd64-msvc194-release-static-patched.log](https://github.com/user-attachments/files/27345070/libmodbus-3.1.12-windows-amd64-msvc194-release-static-patched.log)

Regards!

#### Environment

OS: Windows
CPU: x86_64
Build type: Release
Compiler: Visual Studio - MSVC 194
Libmodbus version: 3.1.12
