### PR TITLE
[TCP] Apply IPv4 socket options to accepted sockets in modbus_tcp_accept

### DIFF
--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -809,6 +809,18 @@ int modbus_tcp_accept(modbus_t *ctx, int *s)
         return -1;
     }
 
+    if (_modbus_tcp_set_ipv4_options(ctx->s) == -1) {
+        if (ctx->debug) {
+            fprintf(
+                stderr,
+                "ERROR Failed to set IPv4 options on accepted socket %d\n",
+                ctx->s);
+        }
+        close(ctx->s);
+        ctx->s = -1;
+        return -1;
+    }
+
     if (ctx->debug) {
         char buf[INET_ADDRSTRLEN];
         if (inet_ntop(AF_INET, &(addr.sin_addr), buf, INET_ADDRSTRLEN) == NULL) {


### PR DESCRIPTION
Fixes #849.

`modbus_tcp_accept()` did not call `_modbus_tcp_set_ipv4_options()` on
the accepted socket, leaving Nagle's algorithm enabled and missing the
`IPTOS_LOWDELAY` TOS marking on the server side. This created an
asymmetry with the client connect path.

## Change

A single call to `_modbus_tcp_set_ipv4_options(ctx->s)` is added in
`modbus_tcp_accept` immediately after the `FD_SETSIZE` validation. On
failure the socket is closed and the function returns -1, matching the
existing error-handling style in the same function. The helper already
contains the necessary platform guards, so no additional preprocessor
logic is needed at the call site.

## Scope

This PR intentionally addresses only the IPv4 path (`modbus_tcp_accept`).
The IPv6 / protocol-independent path (`modbus_tcp_pi_accept`) is left
for a follow-up, since the helper is IPv4-only (it sets `IPPROTO_IP`/
`IP_TOS`) and the IPv6 case needs a slightly different approach.