### PR TITLE
Fix typo: duplicate "use" in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ The function will return an opaque structure called `modbus_t` containing all
 necessary information to establish a connection with other Modbus devices
 according to the selected backend.
 
-Once this context has been created, you can use use the common API provided by
+Once this context has been created, you can use the common API provided by
 *libmodbus* to read/write or set the various timeouts. With this common API,
 it's easy to switch the backend of your application from RTU to TCP IPv6 for
 example.


### PR DESCRIPTION
Small documentation fix — the word "use" appears twice in a row in 
docs/index.md on line 50:

> Once this context has been created, you can use use the common API...

This PR removes the duplicate word.