### PR TITLE
Fix freeaddrinfo(NULL) in _modbus_tcp_pi_connect

### DIFF
--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -445,7 +445,9 @@ static int _modbus_tcp_pi_connect(modbus_t *ctx)
             fprintf(stderr, "Error returned by getaddrinfo: %d\n", rc);
 #endif
         }
-        freeaddrinfo(ai_list);
+        if (ai_list != NULL) {
+            freeaddrinfo(ai_list);
+        }
         errno = ECONNREFUSED;
         return -1;
     }


### PR DESCRIPTION
## Summary

Completes the fix from #831 / 26dc8a5 by applying the same `NULL`-guard
to the client-side mirror function `_modbus_tcp_pi_connect`, which has
identical error-handling code and was overlooked when the server-side
function was patched.

Closes #852.

## Root cause

`_modbus_tcp_pi_connect` in `src/modbus-tcp.c` calls
`freeaddrinfo(ai_list)` unconditionally when `getaddrinfo()` fails:

```c
ai_list = NULL;
rc = getaddrinfo(ctx_tcp_pi->node, ctx_tcp_pi->service, &ai_hints, &ai_list);
if (rc != 0) {
    if (ctx->debug) { ... }
    freeaddrinfo(ai_list);   /* may be NULL */
    errno = ECONNREFUSED;
    return -1;
}
```

POSIX leaves the contents of `*res` unspecified on `getaddrinfo()`
failure, and `freeaddrinfo(NULL)` is undefined behaviour. The
practical breakdown:

| libc        | `freeaddrinfo(NULL)` behaviour |
|-------------|-------------------------------|
| glibc       | Silently tolerated (latent)   |
| uClibc      | Mostly tolerated              |
| **musl**    | **SIGSEGV**                   |

Alpine, OpenWrt, Void (musl variant), and most musl-based Buildroot/
Yocto images are therefore vulnerable. The trigger is not a malformed
packet — it's a hostname that fails to resolve, which is routine
operational reality on industrial gateways during DHCP/DNS warm-up,
transient DNS outages, or configuration typos.

See #852 for the full bug report, reproduction steps, and impact analysis.

## Fix

```diff
--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -437,7 +437,9 @@ static int _modbus_tcp_pi_connect(modbus_t *ctx)
             fprintf(stderr, "Error returned by getaddrinfo: %d\n", rc);
 #endif
         }
-        freeaddrinfo(ai_list);
+        if (ai_list != NULL) {
+            freeaddrinfo(ai_list);
+        }
         errno = ECONNREFUSED;
         return -1;
     }
```