### PR TITLE
Fix validation of FC22 echoed confirmation fields

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -690,6 +690,17 @@ static int check_confirmation(modbus_t *ctx, uint8_t *req, uint8_t *rsp, int rsp
             /* 1 Write functions & others */
             req_nb_value = rsp_nb_value = 1;
             break;
+        case MODBUS_FC_MASK_WRITE_REGISTER:
+            /* FC22 confirmations echo the address and both masks. */
+            if ((req[offset + 1] != rsp[offset + 1]) ||
+                (req[offset + 2] != rsp[offset + 2])) {
+                resp_addr_ok = FALSE;
+            }
+            if (memcmp(req + offset + 3, rsp + offset + 3, 4) != 0) {
+                resp_data_ok = FALSE;
+            }
+            req_nb_value = rsp_nb_value = 1;
+            break;
         default:
             /* 1 Write functions & others */
             req_nb_value = rsp_nb_value = 1;

--- a/tests/unit-test-client.c
+++ b/tests/unit-test-client.c
@@ -319,6 +319,19 @@ int main(int argc, char *argv[])
     ASSERT_TRUE(
         tab_rp_registers[0] == 0x17, "FAILED (%0X != %0X)\n", tab_rp_registers[0], 0x17);
 
+    printf("1/3 Reject mismatched mask-write address: ");
+    rc = modbus_mask_write_register(
+        ctx, UT_REGISTERS_ADDRESS_BAD_MASK_WRITE_ADDRESS, 0xF2, 0x25);
+    ASSERT_TRUE(rc == -1 && errno == EMBBADDATA, "");
+    printf("2/3 Reject mismatched mask-write AND mask: ");
+    rc = modbus_mask_write_register(
+        ctx, UT_REGISTERS_ADDRESS_BAD_MASK_WRITE_AND, 0xF2, 0x25);
+    ASSERT_TRUE(rc == -1 && errno == EMBBADDATA, "");
+    printf("3/3 Reject mismatched mask-write OR mask: ");
+    rc = modbus_mask_write_register(
+        ctx, UT_REGISTERS_ADDRESS_BAD_MASK_WRITE_OR, 0xF2, 0x25);
+    ASSERT_TRUE(rc == -1 && errno == EMBBADDATA, "");
+
     printf("\nTEST FLOATS\n");
     /** FLOAT **/
     printf("1/4 Set/get float ABCD: ");

--- a/tests/unit-test-server.c
+++ b/tests/unit-test-server.c
@@ -227,6 +227,17 @@ int main(int argc, char *argv[])
                        "value (%d) in modbus_reply\n",
                        rc);
             }
+        } else if (function == MODBUS_FC_MASK_WRITE_REGISTER) {
+            if (address == UT_REGISTERS_ADDRESS_BAD_MASK_WRITE_ADDRESS) {
+                printf("Reply with a mismatched address for FC22\n");
+                MODBUS_SET_INT16_TO_INT8(query, header_length + 1, address + 1);
+            } else if (address == UT_REGISTERS_ADDRESS_BAD_MASK_WRITE_AND) {
+                printf("Reply with a mismatched AND mask for FC22\n");
+                query[header_length + 3] ^= 0xFF;
+            } else if (address == UT_REGISTERS_ADDRESS_BAD_MASK_WRITE_OR) {
+                printf("Reply with a mismatched OR mask for FC22\n");
+                query[header_length + 5] ^= 0xFF;
+            }
         }
 
         rc = modbus_reply(ctx, query, rc, mb_mapping);

--- a/tests/unit-test.h.in
+++ b/tests/unit-test.h.in
@@ -49,6 +49,10 @@ const uint16_t UT_REGISTERS_ADDRESS_INVALID_TID_OR_SLAVE = 0x171;
 const uint16_t UT_REGISTERS_ADDRESS_SLEEP_500_MS = 0x172;
 /* The server will wait for 5 ms before sending each byte */
 const uint16_t UT_REGISTERS_ADDRESS_BYTE_SLEEP_5_MS = 0x173;
+/* The server corrupts one echoed FC22 field for each of these requests. */
+const uint16_t UT_REGISTERS_ADDRESS_BAD_MASK_WRITE_ADDRESS = 0x174;
+const uint16_t UT_REGISTERS_ADDRESS_BAD_MASK_WRITE_AND = 0x175;
+const uint16_t UT_REGISTERS_ADDRESS_BAD_MASK_WRITE_OR = 0x176;
 
 /* If the following value is used, a bad response is sent.
    It's better to test with a lower value than


### PR DESCRIPTION
## What changed

- add a dedicated FC22 confirmation case in `check_confirmation()`
- require the echoed reference address, AND mask, and OR mask to match the request
- add independent integration regressions for a mismatch in each echoed field

## Why

The Modbus specification defines the normal Mask Write Register response as an exact echo of the request fields. FC22 previously fell through to the generic one-value case, so a response with the correct function and length could be accepted even when the echoed address or masks differed.

Fixes #868.

## Validation

- `git diff --check`
- `./autogen.sh`
- `./configure --disable-shared`
- `make -j4`
- `tests/unit-tests.sh` — `ALL TESTS PASS WITH SUCCESS`

One earlier full-suite run hit the pre-existing timing-sensitive 7 ms byte-timeout test on macOS; the FC22 regressions passed in that run, and a clean rerun of the complete integration script passed.