### PR TITLE
modbus-tcp: check if response slave id matches request slave id

### DIFF
--- a/src/modbus-tcp.c
+++ b/src/modbus-tcp.c
@@ -225,6 +225,18 @@ static int _modbus_tcp_pre_check_confirmation(modbus_t *ctx,
         return -1;
     }
 
+    /* Check if response slave ID matches request slave ID*/
+    if (req[6] != rsp[6]) {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "The responding slave %d isn't the requested slave %d\n",
+                    rsp[6],
+                    req[6]);
+        }
+        errno = EMBBADSLAVE;
+        return -1;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Current modbus tcp doesn't validate unit identifier, but the rtu does. When one device has multiple ids, it could respond to a wrong request and the master would accept it. 